### PR TITLE
feat: enhance trace output with semantic module naming

### DIFF
--- a/examples/reactive_agents/main.go
+++ b/examples/reactive_agents/main.go
@@ -283,6 +283,14 @@ func (h *PROpenedHandler) Clone() core.Module {
 	return &PROpenedHandler{}
 }
 
+func (h *PROpenedHandler) GetDisplayName() string {
+	return "PR Opened Handler"
+}
+
+func (h *PROpenedHandler) GetModuleType() string {
+	return "orchestrator"
+}
+
 // PrimaryReviewHandler handles general code review.
 type PrimaryReviewHandler struct{}
 
@@ -373,6 +381,14 @@ func (h *PrimaryReviewHandler) Clone() core.Module {
 	return &PrimaryReviewHandler{}
 }
 
+func (h *PrimaryReviewHandler) GetDisplayName() string {
+	return "Primary Code Review Handler"
+}
+
+func (h *PrimaryReviewHandler) GetModuleType() string {
+	return "review"
+}
+
 // SecurityReviewHandler handles security-focused review.
 type SecurityReviewHandler struct{}
 
@@ -457,6 +473,14 @@ func (h *SecurityReviewHandler) SetLLM(llm core.LLM)                   {}
 
 func (h *SecurityReviewHandler) Clone() core.Module {
 	return &SecurityReviewHandler{}
+}
+
+func (h *SecurityReviewHandler) GetDisplayName() string {
+	return "Security Review Handler"
+}
+
+func (h *SecurityReviewHandler) GetModuleType() string {
+	return "security_review"
 }
 
 // PerformanceReviewHandler handles performance-focused review.
@@ -545,6 +569,14 @@ func (h *PerformanceReviewHandler) Clone() core.Module {
 	return &PerformanceReviewHandler{}
 }
 
+func (h *PerformanceReviewHandler) GetDisplayName() string {
+	return "Performance Review Handler"
+}
+
+func (h *PerformanceReviewHandler) GetModuleType() string {
+	return "performance_review"
+}
+
 // StyleReviewHandler handles code style review.
 type StyleReviewHandler struct{}
 
@@ -631,6 +663,14 @@ func (h *StyleReviewHandler) Clone() core.Module {
 	return &StyleReviewHandler{}
 }
 
+func (h *StyleReviewHandler) GetDisplayName() string {
+	return "Code Style Review Handler"
+}
+
+func (h *StyleReviewHandler) GetModuleType() string {
+	return "style_review"
+}
+
 // ReviewCompletedHandler aggregates individual review results.
 type ReviewCompletedHandler struct{}
 
@@ -653,6 +693,14 @@ func (h *ReviewCompletedHandler) Clone() core.Module {
 	return &ReviewCompletedHandler{}
 }
 
+func (h *ReviewCompletedHandler) GetDisplayName() string {
+	return "Review Aggregation Handler"
+}
+
+func (h *ReviewCompletedHandler) GetModuleType() string {
+	return "aggregator"
+}
+
 // FinalReviewHandler creates the final review summary.
 type FinalReviewHandler struct{}
 
@@ -673,6 +721,14 @@ func (h *FinalReviewHandler) SetLLM(llm core.LLM)                   {}
 
 func (h *FinalReviewHandler) Clone() core.Module {
 	return &FinalReviewHandler{}
+}
+
+func (h *FinalReviewHandler) GetDisplayName() string {
+	return "Final Review Summary Handler"
+}
+
+func (h *FinalReviewHandler) GetModuleType() string {
+	return "finalizer"
 }
 
 // determineRequiredSpecialists analyzes a PR to determine which specialists are needed.

--- a/pkg/agents/communication/communication.go
+++ b/pkg/agents/communication/communication.go
@@ -636,6 +636,14 @@ func (m *MessageHandlerModule) Clone() core.Module {
 	return &MessageHandlerModule{agent: m.agent}
 }
 
+func (m *MessageHandlerModule) GetDisplayName() string {
+	return "MessageHandler"
+}
+
+func (m *MessageHandlerModule) GetModuleType() string {
+	return "MessageHandler"
+}
+
 // HelpRequestHandlerModule handles help requests from other agents.
 type HelpRequestHandlerModule struct {
 	agent *Agent
@@ -709,6 +717,14 @@ func (m *HelpRequestHandlerModule) Clone() core.Module {
 	return &HelpRequestHandlerModule{agent: m.agent}
 }
 
+func (m *HelpRequestHandlerModule) GetDisplayName() string {
+	return "HelpRequestHandler"
+}
+
+func (m *HelpRequestHandlerModule) GetModuleType() string {
+	return "HelpRequestHandler"
+}
+
 // HelpResponseHandlerModule handles responses to help requests.
 type HelpResponseHandlerModule struct {
 	agent *Agent
@@ -745,6 +761,14 @@ func (m *HelpResponseHandlerModule) SetLLM(llm core.LLM)                   {}
 
 func (m *HelpResponseHandlerModule) Clone() core.Module {
 	return &HelpResponseHandlerModule{agent: m.agent}
+}
+
+func (m *HelpResponseHandlerModule) GetDisplayName() string {
+	return "HelpResponseHandler"
+}
+
+func (m *HelpResponseHandlerModule) GetModuleType() string {
+	return "HelpResponseHandler"
 }
 
 // StatusUpdateHandlerModule handles status updates from other agents.
@@ -790,4 +814,12 @@ func (m *StatusUpdateHandlerModule) SetLLM(llm core.LLM)                   {}
 
 func (m *StatusUpdateHandlerModule) Clone() core.Module {
 	return &StatusUpdateHandlerModule{agent: m.agent}
+}
+
+func (m *StatusUpdateHandlerModule) GetDisplayName() string {
+	return "StatusUpdateHandler"
+}
+
+func (m *StatusUpdateHandlerModule) GetModuleType() string {
+	return "StatusUpdateHandler"
 }

--- a/pkg/agents/communication/communication_test.go
+++ b/pkg/agents/communication/communication_test.go
@@ -771,6 +771,14 @@ func (m *MockModule) Clone() core.Module {
 	return &MockModule{processFunc: m.processFunc, signature: m.signature}
 }
 
+func (m *MockModule) GetDisplayName() string {
+	return "MockModule"
+}
+
+func (m *MockModule) GetModuleType() string {
+	return "MockModule"
+}
+
 // Test MessageHandlerModule.
 func TestMessageHandlerModule(t *testing.T) {
 	memory := agents.NewInMemoryStore()

--- a/pkg/agents/workflows/advanced.go
+++ b/pkg/agents/workflows/advanced.go
@@ -91,7 +91,7 @@ func (cw *CompositeWorkflow) executeSequentialStage(ctx context.Context, stage *
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Convert map[string]any to map[string]interface{}
 	converted := make(map[string]interface{})
 	for k, v := range result {
@@ -316,8 +316,8 @@ func (cw *CompositeWorkflow) executeNestedWorkflow(ctx context.Context, nestedBu
 // ConditionalRouterWorkflow handles conditional routing patterns.
 type ConditionalRouterWorkflow struct {
 	*BaseWorkflow
-	classifier core.Module
-	routes     map[string]*Step
+	classifier   core.Module
+	routes       map[string]*Step
 	defaultRoute *Step
 }
 
@@ -424,4 +424,14 @@ func (ccm *conditionalClassifierModule) SetSignature(signature core.Signature) {
 func (ccm *conditionalClassifierModule) SetLLM(llm core.LLM)                   {}
 func (ccm *conditionalClassifierModule) Clone() core.Module {
 	return &conditionalClassifierModule{condition: ccm.condition}
+}
+
+// GetDisplayName returns a display name for the conditional classifier.
+func (ccm *conditionalClassifierModule) GetDisplayName() string {
+	return "ConditionalClassifier"
+}
+
+// GetModuleType returns the module type.
+func (ccm *conditionalClassifierModule) GetModuleType() string {
+	return "ConditionalClassifier"
 }

--- a/pkg/agents/workflows/advanced_test.go
+++ b/pkg/agents/workflows/advanced_test.go
@@ -52,6 +52,14 @@ func (m *advancedMockModule) Clone() core.Module {
 	return &advancedMockModule{id: m.id + "_clone", outputs: m.outputs}
 }
 
+func (m *advancedMockModule) GetDisplayName() string {
+	return "AdvancedMockModule_" + m.id
+}
+
+func (m *advancedMockModule) GetModuleType() string {
+	return "test"
+}
+
 func TestWorkflowBuilder_ForEach(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -558,6 +566,14 @@ func (m *slowMockModule) Clone() core.Module {
 	return &slowMockModule{id: m.id + "_clone", outputs: m.outputs, delay: m.delay}
 }
 
+func (m *slowMockModule) GetDisplayName() string {
+	return "SlowMockModule_" + m.id
+}
+
+func (m *slowMockModule) GetModuleType() string {
+	return "test"
+}
+
 // Error scenario mock module.
 type errorMockModule struct {
 	id string
@@ -584,6 +600,14 @@ func (m *errorMockModule) Clone() core.Module {
 	return &errorMockModule{id: m.id + "_clone"}
 }
 
+func (m *errorMockModule) GetDisplayName() string {
+	return "ErrorMockModule_" + m.id
+}
+
+func (m *errorMockModule) GetModuleType() string {
+	return "test"
+}
+
 // badFieldClassifierModule returns wrong field name.
 type badFieldClassifierModule struct{}
 
@@ -601,6 +625,14 @@ func (bfcm *badFieldClassifierModule) Clone() core.Module {
 	return &badFieldClassifierModule{}
 }
 
+func (bfcm *badFieldClassifierModule) GetDisplayName() string {
+	return "BadFieldClassifierModule"
+}
+
+func (bfcm *badFieldClassifierModule) GetModuleType() string {
+	return "test"
+}
+
 // intClassifierModule returns integer classification.
 type intClassifierModule struct{}
 
@@ -616,6 +648,14 @@ func (icm *intClassifierModule) SetSignature(signature core.Signature) {}
 func (icm *intClassifierModule) SetLLM(llm core.LLM)                   {}
 func (icm *intClassifierModule) Clone() core.Module {
 	return &intClassifierModule{}
+}
+
+func (icm *intClassifierModule) GetDisplayName() string {
+	return "IntClassifierModule"
+}
+
+func (icm *intClassifierModule) GetModuleType() string {
+	return "test"
 }
 
 func TestCompositeWorkflow_TimeoutHandling(t *testing.T) {

--- a/pkg/agents/workflows/builder_test.go
+++ b/pkg/agents/workflows/builder_test.go
@@ -34,6 +34,14 @@ func (m *testModule) SetSignature(signature core.Signature) {}
 func (m *testModule) SetLLM(llm core.LLM)                   {}
 func (m *testModule) Clone() core.Module                    { return &testModule{id: m.id + "_clone"} }
 
+func (m *testModule) GetDisplayName() string {
+	return "TestModule_" + m.id
+}
+
+func (m *testModule) GetModuleType() string {
+	return "test"
+}
+
 func TestWorkflowBuilder_NewBuilder(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/agents/workflows/reactive_test.go
+++ b/pkg/agents/workflows/reactive_test.go
@@ -88,6 +88,14 @@ func (m *ReactiveMockModule) Clone() core.Module {
 	return &ReactiveMockModule{processFunc: m.processFunc}
 }
 
+func (m *ReactiveMockModule) GetDisplayName() string {
+	return "ReactiveMockModule"
+}
+
+func (m *ReactiveMockModule) GetModuleType() string {
+	return "test"
+}
+
 func TestEventBus_BasicFunctionality(t *testing.T) {
 	config := DefaultEventBusConfig()
 	config.BufferSize = 10

--- a/pkg/agents/workflows/workflow_test.go
+++ b/pkg/agents/workflows/workflow_test.go
@@ -66,6 +66,22 @@ func (m *MockModule) Clone() core.Module {
 	return args.Get(0).(core.Module)
 }
 
+func (m *MockModule) GetDisplayName() string {
+	args := m.Called()
+	if len(args) > 0 {
+		return args.String(0)
+	}
+	return "MockModule"
+}
+
+func (m *MockModule) GetModuleType() string {
+	args := m.Called()
+	if len(args) > 0 {
+		return args.String(0)
+	}
+	return "mock"
+}
+
 func TestBaseWorkflow(t *testing.T) {
 	t.Run("AddStep success", func(t *testing.T) {
 		memory := new(MockMemory)

--- a/pkg/core/module.go
+++ b/pkg/core/module.go
@@ -20,6 +20,12 @@ type Module interface {
 
 	// Clone creates a deep copy of the module
 	Clone() Module
+
+	// GetDisplayName returns a human-readable name for this module instance
+	GetDisplayName() string
+
+	// GetModuleType returns the category/type of this module
+	GetModuleType() string
 }
 
 type Option func(*ModuleOptions)
@@ -86,8 +92,10 @@ func WithOptions(opts ...Option) Option {
 
 // BaseModule provides a basic implementation of the Module interface.
 type BaseModule struct {
-	Signature Signature
-	LLM       LLM
+	Signature   Signature
+	LLM         LLM
+	DisplayName string
+	ModuleType  string
 }
 
 // GetSignature returns the module's signature.
@@ -104,6 +112,22 @@ func (bm *BaseModule) SetSignature(signature Signature) {
 	bm.Signature = signature
 }
 
+// GetDisplayName returns the human-readable name for this module instance.
+func (bm *BaseModule) GetDisplayName() string {
+	if bm.DisplayName != "" {
+		return bm.DisplayName
+	}
+	return bm.GetModuleType()
+}
+
+// GetModuleType returns the category/type of this module.
+func (bm *BaseModule) GetModuleType() string {
+	if bm.ModuleType != "" {
+		return bm.ModuleType
+	}
+	return "BaseModule"
+}
+
 // Process is a placeholder implementation and should be overridden by specific modules.
 func (bm *BaseModule) Process(ctx context.Context, inputs map[string]any, opts ...Option) (map[string]any, error) {
 	return nil, errors.New("Process method not implemented")
@@ -112,8 +136,10 @@ func (bm *BaseModule) Process(ctx context.Context, inputs map[string]any, opts .
 // Clone creates a deep copy of the BaseModule.
 func (bm *BaseModule) Clone() Module {
 	return &BaseModule{
-		Signature: bm.Signature,
-		LLM:       bm.LLM, // Note: This is a shallow copy of the LLM
+		Signature:   bm.Signature,
+		LLM:         bm.LLM, // Note: This is a shallow copy of the LLM
+		DisplayName: bm.DisplayName,
+		ModuleType:  bm.ModuleType,
 	}
 }
 

--- a/pkg/core/program_test.go
+++ b/pkg/core/program_test.go
@@ -38,6 +38,22 @@ func (m *MockModule) SetSignature(signature Signature) {
 	m.Called(signature)
 }
 
+func (m *MockModule) GetDisplayName() string {
+	args := m.Called()
+	if len(args) > 0 {
+		return args.String(0)
+	}
+	return "MockModule"
+}
+
+func (m *MockModule) GetModuleType() string {
+	args := m.Called()
+	if len(args) > 0 {
+		return args.String(0)
+	}
+	return "mock"
+}
+
 func TestProgram(t *testing.T) {
 	t.Run("NewProgram", func(t *testing.T) {
 		mockModule := new(MockModule)

--- a/pkg/core/state_test.go
+++ b/pkg/core/state_test.go
@@ -119,6 +119,16 @@ func (m *StateTestMockModule) Clone() Module {
 	return cloned
 }
 
+// GetDisplayName implements Module.
+func (m *StateTestMockModule) GetDisplayName() string {
+	return "StateTestMockModule"
+}
+
+// GetModuleType implements Module.
+func (m *StateTestMockModule) GetModuleType() string {
+	return "test"
+}
+
 // Another mock type for mismatch testing.
 type AnotherMockModule struct {
 	BaseModule

--- a/pkg/logging/outputs.go
+++ b/pkg/logging/outputs.go
@@ -660,6 +660,16 @@ func formatSpanTree(b *strings.Builder, span *core.Span, spanMap map[string]*cor
 	}
 
 	spanInfo := fmt.Sprintf("%s%s %s", prefix, marker, span.Operation)
+	
+	// Add module context information if available
+	if moduleInfo, ok := span.Annotations["module"].(map[string]interface{}); ok {
+		// Module context was already included in span.Operation by StartSpanWithContext
+		// but we can add additional type information if helpful
+		if moduleType, ok := moduleInfo["type"].(string); ok && moduleType != "" {
+			spanInfo += fmt.Sprintf(" [%s]", moduleType)
+		}
+	}
+	
 	if chainInfo, ok := span.Annotations["chain_step"].(map[string]interface{}); ok {
 		if stepName, ok := chainInfo["name"].(string); ok {
 			spanInfo += fmt.Sprintf(" (step=%s)", stepName)

--- a/pkg/modules/chain_of_thought.go
+++ b/pkg/modules/chain_of_thought.go
@@ -22,6 +22,69 @@ func NewChainOfThought(signature core.Signature) *ChainOfThought {
 	}
 }
 
+// WithName sets a semantic name for this ChainOfThought instance.
+func (c *ChainOfThought) WithName(name string) *ChainOfThought {
+	c.Predict.DisplayName = name
+	return c
+}
+
+// GetDisplayName returns the display name for this ChainOfThought module.
+func (c *ChainOfThought) GetDisplayName() string {
+	// Use the Predict module's custom name if it was set, otherwise use "ChainOfThought"
+	predictName := c.Predict.GetDisplayName()
+	if predictName != "" && predictName != "Predict" && predictName != "BaseModule" {
+		return predictName
+	}
+	return "ChainOfThought"
+}
+
+// GetModuleType returns "ChainOfThought".
+func (c *ChainOfThought) GetModuleType() string {
+	return "ChainOfThought"
+}
+
+// GetSignature returns the signature from the internal Predict module.
+func (c *ChainOfThought) GetSignature() core.Signature {
+	return c.Predict.GetSignature()
+}
+
+// SetSignature sets the signature on the internal Predict module with rationale field.
+func (c *ChainOfThought) SetSignature(signature core.Signature) {
+	modifiedSignature := appendRationaleField(signature)
+	c.Predict.SetSignature(modifiedSignature)
+}
+
+// SetLLM sets the LLM on the internal Predict module.
+func (c *ChainOfThought) SetLLM(llm core.LLM) {
+	c.Predict.SetLLM(llm)
+}
+
+// Clone creates a deep copy of the ChainOfThought module.
+func (c *ChainOfThought) Clone() core.Module {
+	return &ChainOfThought{
+		Predict: c.Predict.Clone().(*Predict),
+	}
+}
+
+// Compose creates a new module that chains this module with the next module.
+func (c *ChainOfThought) Compose(next core.Module) core.Module {
+	return core.NewModuleChain(c, next)
+}
+
+// GetSubModules returns the sub-modules of this ChainOfThought.
+func (c *ChainOfThought) GetSubModules() []core.Module {
+	return []core.Module{c.Predict}
+}
+
+// SetSubModules sets the sub-modules (expects exactly one Predict module).
+func (c *ChainOfThought) SetSubModules(modules []core.Module) {
+	if len(modules) == 1 {
+		if predict, ok := modules[0].(*Predict); ok {
+			c.Predict = predict
+		}
+	}
+}
+
 // WithDefaultOptions sets default options by configuring the underlying Predict module.
 func (c *ChainOfThought) WithDefaultOptions(opts ...core.Option) *ChainOfThought {
 	// Simply delegate to the Predict module's WithDefaultOptions
@@ -30,7 +93,14 @@ func (c *ChainOfThought) WithDefaultOptions(opts ...core.Option) *ChainOfThought
 }
 
 func (c *ChainOfThought) Process(ctx context.Context, inputs map[string]any, opts ...core.Option) (map[string]any, error) {
-	ctx, span := core.StartSpan(ctx, "ChainOfThought")
+	// Use ChainOfThought's own display name
+	displayName := c.GetDisplayName()
+
+	metadata := map[string]interface{}{
+		"module_type":   c.GetModuleType(),
+		"module_config": c.GetSignature().String(),
+	}
+	ctx, span := core.StartSpanWithContext(ctx, "ChainOfThought", displayName, metadata)
 	defer core.EndSpan(ctx)
 
 	span.WithAnnotation("inputs", inputs)
@@ -42,43 +112,6 @@ func (c *ChainOfThought) Process(ctx context.Context, inputs map[string]any, opt
 	span.WithAnnotation("outputs", outputs)
 
 	return outputs, nil
-}
-
-func (c *ChainOfThought) GetSignature() core.Signature {
-	return c.Predict.GetSignature()
-}
-
-// SetSignature implements the core.Module interface.
-func (c *ChainOfThought) SetSignature(signature core.Signature) {
-	modifiedSignature := appendRationaleField(signature)
-	c.Predict.SetSignature(modifiedSignature)
-}
-
-func (c *ChainOfThought) SetLLM(llm core.LLM) {
-	c.Predict.SetLLM(llm)
-}
-
-func (c *ChainOfThought) Clone() core.Module {
-	return &ChainOfThought{
-		Predict: c.Predict.Clone().(*Predict),
-	}
-}
-func (c *ChainOfThought) Compose(next core.Module) core.Module {
-	return &core.ModuleChain{
-		Modules: []core.Module{c, next},
-	}
-}
-
-func (c *ChainOfThought) GetSubModules() []core.Module {
-	return []core.Module{c.Predict}
-}
-
-func (c *ChainOfThought) SetSubModules(modules []core.Module) {
-	if len(modules) > 0 {
-		if predict, ok := modules[0].(*Predict); ok {
-			c.Predict = predict
-		}
-	}
 }
 func appendRationaleField(signature core.Signature) core.Signature {
 	newSignature := signature

--- a/pkg/modules/chain_of_thought.go
+++ b/pkg/modules/chain_of_thought.go
@@ -30,10 +30,9 @@ func (c *ChainOfThought) WithName(name string) *ChainOfThought {
 
 // GetDisplayName returns the display name for this ChainOfThought module.
 func (c *ChainOfThought) GetDisplayName() string {
-	// Use the Predict module's custom name if it was set, otherwise use "ChainOfThought"
-	predictName := c.Predict.GetDisplayName()
-	if predictName != "" && predictName != "Predict" && predictName != "BaseModule" {
-		return predictName
+	// If the inner Predict module has a custom display name, use it.
+	if c.Predict.DisplayName != "" {
+		return c.Predict.DisplayName
 	}
 	return "ChainOfThought"
 }

--- a/pkg/modules/chain_of_thought_test.go
+++ b/pkg/modules/chain_of_thought_test.go
@@ -50,8 +50,8 @@ answer:
 	spans := core.CollectSpans(ctx)
 	require.Len(t, spans, 2, "Should have two spans")
 
-	assert.Equal(t, "ChainOfThought", spans[0].Operation)
-	assert.Equal(t, "Predict", spans[1].Operation)
+	assert.Equal(t, "ChainOfThought (ChainOfThought)", spans[0].Operation)
+	assert.Equal(t, "Predict (Predict)", spans[1].Operation)
 	assert.Equal(t, spans[0].ID, spans[1].ParentID)
 	rootSpan := spans[0]
 

--- a/pkg/modules/parallel.go
+++ b/pkg/modules/parallel.go
@@ -81,11 +81,21 @@ func NewParallel(module core.Module, opts ...ParallelOption) *Parallel {
 	// Copy the signature from the inner module
 	signature := module.GetSignature()
 
+	baseModule := core.NewModule(signature)
+	baseModule.ModuleType = "Parallel"
+	baseModule.DisplayName = "" // Will be set by user or derived from context
+
 	return &Parallel{
-		BaseModule:  *core.NewModule(signature),
+		BaseModule:  *baseModule,
 		innerModule: module,
 		options:     options,
 	}
+}
+
+// WithName sets a semantic name for this Parallel instance.
+func (p *Parallel) WithName(name string) *Parallel {
+	p.DisplayName = name
+	return p
 }
 
 // ParallelOption is a function that configures ParallelOptions.

--- a/pkg/modules/predict.go
+++ b/pkg/modules/predict.go
@@ -152,7 +152,7 @@ func (p *Predict) processWithStreaming(ctx context.Context, inputs map[string]in
 	logger := logging.GetLogger()
 	// Use semantic name if set, otherwise fall back to operation name
 	displayName := p.GetDisplayName()
-	if displayName == "" || displayName == "BaseModule" {
+	if displayName == p.GetModuleType() {
 		displayName = "PredictStream"
 	}
 

--- a/pkg/modules/react_test.go
+++ b/pkg/modules/react_test.go
@@ -76,9 +76,9 @@ func TestReAct(t *testing.T) {
 	spans := core.CollectSpans(ctx)
 	require.Len(t, spans, 4)
 	assert.Equal(t, "ReAct", spans[0].Operation)
-	assert.Equal(t, "Predict", spans[1].Operation)
+	assert.Equal(t, "Predict (Predict)", spans[1].Operation)
 	assert.Equal(t, "executeToolByName", spans[2].Operation)
-	assert.Equal(t, "Predict", spans[3].Operation)
+	assert.Equal(t, "Predict (Predict)", spans[3].Operation)
 }
 
 func TestReAct_WithErroredTool(t *testing.T) {

--- a/pkg/optimizers/copro_test.go
+++ b/pkg/optimizers/copro_test.go
@@ -39,6 +39,22 @@ func (m *MockModule) SetSignature(signature core.Signature) {
 	m.Called(signature)
 }
 
+func (m *MockModule) GetDisplayName() string {
+	args := m.Called()
+	if len(args) > 0 {
+		return args.String(0)
+	}
+	return "MockModule"
+}
+
+func (m *MockModule) GetModuleType() string {
+	args := m.Called()
+	if len(args) > 0 {
+		return args.String(0)
+	}
+	return "test"
+}
+
 // MockOptimizer is a mock implementation of core.Optimizer.
 type MockOptimizer struct {
 	mock.Mock


### PR DESCRIPTION
This commit improves the tracing system to provide cleaner, more informative trace output by adding semantic module naming capabilities.

Key improvements:
- Added StartSpanWithContext() for enhanced span creation with module metadata
- Extended Module interface with GetDisplayName() and GetModuleType() methods
- Added WithName() fluent API to all modules for semantic instance naming
- Enhanced trace formatting to show both operation and instance names
- Updated all modules and tests to support new interface requirements

Trace output now shows clear module context:
  Before: └── ChainOfThought (1.2m) After:  └── ChainOfThought (UserQueryAnalyzer) (1.2m)