### PR TITLE
optimizers: extract shared evolution loop

### DIFF
--- a/pkg/optimizers/evolution_loop.go
+++ b/pkg/optimizers/evolution_loop.go
@@ -1,0 +1,116 @@
+package optimizers
+
+import (
+	"context"
+	"fmt"
+)
+
+// EvolutionLoopConfig configures the shared GEPA-style generation loop.
+type EvolutionLoopConfig struct {
+	MaxGenerations int
+	ReflectionFreq int
+	PhaseName      string
+}
+
+// EvolutionLoopHooks injects domain-specific behavior into the shared loop.
+type EvolutionLoopHooks struct {
+	Initialize         func(ctx context.Context) error
+	BeforeGeneration   func(ctx context.Context, generation int) error
+	EvaluateGeneration func(ctx context.Context, generation int) error
+	// AfterEvaluation runs immediately after EvaluateGeneration for the same generation.
+	// Callers can use it to consume state populated during evaluation, such as cached
+	// fitness maps needed by archive or frontier updates.
+	AfterEvaluation func(ctx context.Context, generation int) error
+	Reflect         func(ctx context.Context, generation int) error
+	OnNonFatalError func(ctx context.Context, stage string, generation int, err error)
+	HasConverged    func(ctx context.Context, generation int) bool
+	// Evolve is treated as fatal if it returns an error. Hooks that want retry or
+	// best-effort behavior should absorb those failures internally.
+	Evolve         func(ctx context.Context, generation int) error
+	ReportProgress func(phase string, current, total int)
+	Finalize       func(ctx context.Context) error
+}
+
+// RunEvolutionLoop executes the shared GEPA-style generation loop once the caller
+// provides initialization, evaluation, and evolution callbacks.
+func RunEvolutionLoop(ctx context.Context, cfg EvolutionLoopConfig, hooks EvolutionLoopHooks) error {
+	if cfg.MaxGenerations <= 0 {
+		return fmt.Errorf("optimizers: max generations must be positive")
+	}
+	if hooks.EvaluateGeneration == nil {
+		return fmt.Errorf("optimizers: evaluate generation hook is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if hooks.Initialize != nil {
+		if err := hooks.Initialize(ctx); err != nil {
+			return err
+		}
+	}
+
+	for generation := 0; generation < cfg.MaxGenerations; generation++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if hooks.BeforeGeneration != nil {
+			if err := hooks.BeforeGeneration(ctx, generation); err != nil {
+				return err
+			}
+		}
+
+		if err := hooks.EvaluateGeneration(ctx, generation); err != nil {
+			return err
+		}
+
+		if hooks.AfterEvaluation != nil {
+			if err := hooks.AfterEvaluation(ctx, generation); err != nil {
+				return err
+			}
+		}
+
+		if cfg.ReflectionFreq > 0 && generation > 0 && generation%cfg.ReflectionFreq == 0 && hooks.Reflect != nil {
+			if err := hooks.Reflect(ctx, generation); err != nil {
+				if hooks.OnNonFatalError != nil {
+					hooks.OnNonFatalError(ctx, "reflection", generation, err)
+				}
+			}
+		}
+
+		if hooks.HasConverged != nil && hooks.HasConverged(ctx, generation) {
+			break
+		}
+
+		if generation < cfg.MaxGenerations-1 && hooks.Evolve != nil {
+			if err := hooks.Evolve(ctx, generation); err != nil {
+				return err
+			}
+		}
+
+		if hooks.ReportProgress != nil {
+			hooks.ReportProgress(cfg.phaseName(), generation+1, cfg.MaxGenerations)
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if hooks.Finalize != nil {
+		if err := hooks.Finalize(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cfg EvolutionLoopConfig) phaseName() string {
+	if cfg.PhaseName == "" {
+		return "Evolution"
+	}
+
+	return cfg.PhaseName
+}

--- a/pkg/optimizers/evolution_loop_test.go
+++ b/pkg/optimizers/evolution_loop_test.go
@@ -1,0 +1,154 @@
+package optimizers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunEvolutionLoop_OrdersStagesAndSkipsGenerationZeroReflection(t *testing.T) {
+	var calls []string
+	var progress []string
+
+	err := RunEvolutionLoop(context.Background(), EvolutionLoopConfig{
+		MaxGenerations: 3,
+		ReflectionFreq: 1,
+		PhaseName:      "GEPA Evolution",
+	}, EvolutionLoopHooks{
+		Initialize: func(ctx context.Context) error {
+			calls = append(calls, "init")
+			return nil
+		},
+		BeforeGeneration: func(ctx context.Context, generation int) error {
+			calls = append(calls, "before")
+			return nil
+		},
+		EvaluateGeneration: func(ctx context.Context, generation int) error {
+			calls = append(calls, "evaluate")
+			return nil
+		},
+		AfterEvaluation: func(ctx context.Context, generation int) error {
+			calls = append(calls, "after")
+			return nil
+		},
+		Reflect: func(ctx context.Context, generation int) error {
+			calls = append(calls, "reflect")
+			return nil
+		},
+		HasConverged: func(ctx context.Context, generation int) bool {
+			calls = append(calls, "converged")
+			return false
+		},
+		Evolve: func(ctx context.Context, generation int) error {
+			calls = append(calls, "evolve")
+			return nil
+		},
+		ReportProgress: func(phase string, current, total int) {
+			progress = append(progress, phase)
+		},
+		Finalize: func(ctx context.Context) error {
+			calls = append(calls, "finalize")
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"init",
+		"before", "evaluate", "after", "converged", "evolve",
+		"before", "evaluate", "after", "reflect", "converged", "evolve",
+		"before", "evaluate", "after", "reflect", "converged",
+		"finalize",
+	}, calls)
+	assert.Equal(t, []string{"GEPA Evolution", "GEPA Evolution", "GEPA Evolution"}, progress)
+}
+
+func TestRunEvolutionLoop_ContinuesAfterNonFatalReflectionError(t *testing.T) {
+	var nonFatal []string
+	evaluateCalls := 0
+
+	err := RunEvolutionLoop(context.Background(), EvolutionLoopConfig{
+		MaxGenerations: 2,
+		ReflectionFreq: 1,
+	}, EvolutionLoopHooks{
+		EvaluateGeneration: func(ctx context.Context, generation int) error {
+			evaluateCalls++
+			return nil
+		},
+		Reflect: func(ctx context.Context, generation int) error {
+			return errors.New("reflection failed")
+		},
+		OnNonFatalError: func(ctx context.Context, stage string, generation int, err error) {
+			nonFatal = append(nonFatal, stage)
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, evaluateCalls)
+	assert.Equal(t, []string{"reflection"}, nonFatal)
+}
+
+func TestRunEvolutionLoop_StopsAfterConvergence(t *testing.T) {
+	evaluateCalls := 0
+	evolveCalls := 0
+
+	err := RunEvolutionLoop(context.Background(), EvolutionLoopConfig{
+		MaxGenerations: 5,
+		ReflectionFreq: 2,
+	}, EvolutionLoopHooks{
+		EvaluateGeneration: func(ctx context.Context, generation int) error {
+			evaluateCalls++
+			return nil
+		},
+		HasConverged: func(ctx context.Context, generation int) bool {
+			return generation == 1
+		},
+		Evolve: func(ctx context.Context, generation int) error {
+			evolveCalls++
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, evaluateCalls)
+	assert.Equal(t, 1, evolveCalls)
+}
+
+func TestRunEvolutionLoop_ZeroReflectionFreqDoesNotCallReflect(t *testing.T) {
+	err := RunEvolutionLoop(context.Background(), EvolutionLoopConfig{
+		MaxGenerations: 2,
+		ReflectionFreq: 0,
+	}, EvolutionLoopHooks{
+		EvaluateGeneration: func(ctx context.Context, generation int) error {
+			return nil
+		},
+		Reflect: func(ctx context.Context, generation int) error {
+			return errors.New("reflect should not be called")
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+func TestRunEvolutionLoop_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	evaluateCalls := 0
+
+	err := RunEvolutionLoop(ctx, EvolutionLoopConfig{
+		MaxGenerations: 10,
+	}, EvolutionLoopHooks{
+		EvaluateGeneration: func(ctx context.Context, generation int) error {
+			evaluateCalls++
+			if generation == 1 {
+				cancel()
+			}
+			return nil
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 2, evaluateCalls)
+}

--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -2693,60 +2693,65 @@ func (g *GEPA) Compile(ctx context.Context, program core.Program, dataset core.D
 
 	// Install interceptors on the program
 	optimizedProgram := g.installInterceptors(program)
+	err := RunEvolutionLoop(ctx, EvolutionLoopConfig{
+		MaxGenerations: g.config.MaxGenerations,
+		ReflectionFreq: g.config.ReflectionFreq,
+		PhaseName:      "GEPA Evolution",
+	}, EvolutionLoopHooks{
+		Initialize: func(ctx context.Context) error {
+			if err := g.initializePopulation(ctx, optimizedProgram); err != nil {
+				return fmt.Errorf("failed to initialize population: %w", err)
+			}
+			return nil
+		},
+		BeforeGeneration: func(ctx context.Context, generation int) error {
+			g.state.CurrentGeneration = generation
+			logger.Info(ctx, "Starting generation %d", generation)
+			return nil
+		},
+		EvaluateGeneration: func(ctx context.Context, generation int) error {
+			multiObjFitnessMap, err := g.evaluatePopulation(ctx, optimizedProgram, dataset, metric)
+			if err != nil {
+				return fmt.Errorf("evaluation failed at generation %d: %w", generation, err)
+			}
 
-	// Initialize population
-	err := g.initializePopulation(ctx, optimizedProgram)
+			g.setCurrentMultiObjectiveFitnessMap(multiObjFitnessMap)
+			return nil
+		},
+		AfterEvaluation: func(ctx context.Context, generation int) error {
+			currentPop := g.getCurrentPopulation()
+			if currentPop != nil {
+				g.state.UpdateParetoArchive(currentPop.Candidates, g.getCurrentMultiObjectiveFitnessMap())
+			}
+			return nil
+		},
+		Reflect: func(ctx context.Context, generation int) error {
+			return g.performReflection(ctx, generation)
+		},
+		OnNonFatalError: func(ctx context.Context, stage string, generation int, err error) {
+			logger.Error(ctx, "%s failed at generation %d: %v", stage, generation, err)
+		},
+		HasConverged: func(ctx context.Context, generation int) bool {
+			if g.hasConverged() {
+				logger.Info(ctx, "Convergence achieved at generation %d", generation)
+				return true
+			}
+			return false
+		},
+		Evolve: func(ctx context.Context, generation int) error {
+			if err := g.evolvePopulation(ctx); err != nil {
+				return fmt.Errorf("evolution failed at generation %d: %w", generation, err)
+			}
+			return nil
+		},
+		ReportProgress: func(phase string, current, total int) {
+			if g.progressReporter != nil {
+				g.progressReporter.Report(phase, current, total)
+			}
+		},
+	})
 	if err != nil {
-		return program, fmt.Errorf("failed to initialize population: %w", err)
-	}
-
-	// Main evolutionary loop
-	for generation := 0; generation < g.config.MaxGenerations; generation++ {
-		g.state.CurrentGeneration = generation
-
-		logger.Info(ctx, "Starting generation %d", generation)
-
-		// Evaluate current population and get multi-objective fitness map
-		multiObjFitnessMap, err := g.evaluatePopulation(ctx, optimizedProgram, dataset, metric)
-		if err != nil {
-			return program, fmt.Errorf("evaluation failed at generation %d: %w", generation, err)
-		}
-
-		// Store multi-objective fitness map for this generation
-		g.setCurrentMultiObjectiveFitnessMap(multiObjFitnessMap)
-
-		// Update Pareto archive with elite solutions
-		currentPop := g.getCurrentPopulation()
-		if currentPop != nil {
-			g.state.UpdateParetoArchive(currentPop.Candidates, multiObjFitnessMap)
-		}
-
-		// Periodic reflection
-		if generation%g.config.ReflectionFreq == 0 && generation > 0 {
-			err = g.performReflection(ctx, generation)
-			if err != nil {
-				logger.Error(ctx, "Reflection failed at generation %d: %v", generation, err)
-			}
-		}
-
-		// Check convergence
-		if g.hasConverged() {
-			logger.Info(ctx, "Convergence achieved at generation %d", generation)
-			break
-		}
-
-		// Create next generation (skip for last generation)
-		if generation < g.config.MaxGenerations-1 {
-			err = g.evolvePopulation(ctx)
-			if err != nil {
-				return program, fmt.Errorf("evolution failed at generation %d: %w", generation, err)
-			}
-		}
-
-		// Report progress
-		if g.progressReporter != nil {
-			g.progressReporter.Report("GEPA Evolution", generation+1, g.config.MaxGenerations)
-		}
+		return program, err
 	}
 
 	// Apply best candidate to program
@@ -5371,7 +5376,6 @@ func (g *GEPA) batchSelfCritique(ctx context.Context, candidates []*GEPACandidat
 	return results, nil
 }
 
-
 // performIndividualReflection performs reflection on individual candidates.
 func (g *GEPA) performIndividualReflection(ctx context.Context) error {
 	if len(g.state.PopulationHistory) == 0 {
@@ -5409,8 +5413,6 @@ func (g *GEPA) performIndividualReflection(ctx context.Context) error {
 	return nil
 }
 
-
-
 // Supporting structures for multi-level reflection
 
 type IndividualReflectionInsights struct {
@@ -5421,7 +5423,6 @@ type IndividualReflectionInsights struct {
 	ImprovementThemes      []string       `json:"improvement_themes"`
 	ConfidenceDistribution map[string]int `json:"confidence_distribution"`
 }
-
 
 // Implementation of helper methods for multi-level reflection
 
@@ -5723,17 +5724,7 @@ func (g *GEPA) analyzePopulationPatterns() *PopulationInsights {
 	return insights
 }
 
-
-
-
-
 // Placeholder implementations for remaining methods (to be expanded as needed)
-
-
-
-
-
-
 
 func (g *GEPA) extractCommonPatterns(candidates []*GEPACandidate) []string {
 	patterns := make([]string, 0)


### PR DESCRIPTION
## Summary
- extract a shared generation scheduler for GEPA-style optimization loops
- refactor GEPA.Compile to use the shared loop hooks instead of an inline loop
- add coverage for ordering, reflection frequency, convergence, and context cancellation

## Testing
- go test ./pkg/optimizers
- go test ./pkg/agents/optimize ./pkg/agents/react
- golangci-lint run ./...

Part of #210.