### PR TITLE
optimizers: enrich GEPA reflection evidence

### DIFF
--- a/pkg/agents/optimize/gepa_adapter.go
+++ b/pkg/agents/optimize/gepa_adapter.go
@@ -19,7 +19,10 @@ const (
 	gepaMetadataArtifactKeysKey    = "artifact_keys"
 	gepaMetadataPrimaryArtifactKey = "primary_artifact"
 	gepaMetadataTraceSummaryKey    = "rich_trace_summary"
+	gepaMetadataTraceEvidenceKey   = "rich_trace_evidence"
 	maxTraceSummarySteps           = 5
+	maxTraceEvidenceItems          = 8
+	maxFailedStepEvidence          = 4
 )
 
 // GEPAAdapterConfig configures the agent-to-GEPA bridge layer.
@@ -640,6 +643,9 @@ func buildGEPATrace(candidate *optimizers.GEPACandidate, example AgentExample, r
 	trace.ContextData["passed_tests"] = append([]string(nil), sideInfo.PassedTests...)
 	trace.ContextData["failed_tests"] = append([]string(nil), sideInfo.FailedTests...)
 	trace.ContextData["tokens"] = core.ShallowCopyMap(sideInfo.Tokens)
+	if evidence := buildRichTraceEvidence(sideInfo.Trace, sideInfo); len(evidence) > 0 {
+		trace.ContextData[gepaMetadataTraceEvidenceKey] = evidence
+	}
 
 	trace.Success = result.Score >= passThreshold && extractEvalError(sideInfo) == nil
 	trace.Error = extractEvalError(sideInfo)
@@ -713,11 +719,139 @@ func summarizeAgentTrace(trace *agents.ExecutionTrace) string {
 	return builder.String()
 }
 
+func buildRichTraceEvidence(trace *agents.ExecutionTrace, sideInfo *SideInfo) []string {
+	evidence := make([]string, 0, maxTraceEvidenceItems)
+
+	if trace != nil {
+		if trace.TerminationCause != "" {
+			evidence = append(evidence, "termination="+trace.TerminationCause)
+		}
+		if trace.Status != "" {
+			evidence = append(evidence, "trace_status="+string(trace.Status))
+		}
+		if len(trace.Steps) > 0 {
+			evidence = append(evidence, fmt.Sprintf("step_count=%d", len(trace.Steps)))
+			evidence = append(evidence, detectToolLoopEvidence(trace.Steps)...)
+			failedStepCount := 0
+			for _, step := range trace.Steps {
+				if step.Success && step.Error == "" {
+					continue
+				}
+				if failedStepCount >= maxFailedStepEvidence {
+					break
+				}
+				entry := fmt.Sprintf("step%d tool=%s success=%t", step.Index, step.Tool, step.Success)
+				if step.Error != "" {
+					entry += " error=" + truncateString(step.Error, 80)
+				} else if step.Observation != "" {
+					entry += " obs=" + truncateString(step.Observation, 80)
+				}
+				evidence = append(evidence, entry)
+				failedStepCount++
+			}
+		}
+	}
+
+	if sideInfo != nil {
+		for _, failedTest := range sideInfo.FailedTests {
+			evidence = append(evidence, "failed_test="+failedTest)
+		}
+		if sideInfo.Diagnostics != nil {
+			for _, key := range []string{"evaluation_error", "execution_error", "comparison_error"} {
+				if raw, ok := sideInfo.Diagnostics[key]; ok {
+					if message, ok := raw.(string); ok && message != "" {
+						evidence = append(evidence, key+"="+truncateString(message, 80))
+					}
+				}
+			}
+			if mismatches, ok := sideInfo.Diagnostics["mismatches"].(map[string]interface{}); ok && len(mismatches) > 0 {
+				keys := make([]string, 0, len(mismatches))
+				for key := range mismatches {
+					keys = append(keys, key)
+				}
+				sort.Strings(keys)
+				evidence = append(evidence, "mismatch_keys="+strings.Join(keys, ","))
+			}
+		}
+	}
+
+	return dedupeEvidence(evidence, maxTraceEvidenceItems)
+}
+
+// detectToolLoopEvidence intentionally captures only consecutive same-tool runs.
+// More complex alternating loops are possible, but this cheap heuristic already
+// surfaces a common failure pattern without full sequence mining.
+func detectToolLoopEvidence(steps []agents.TraceStep) []string {
+	if len(steps) < 2 {
+		return nil
+	}
+
+	evidence := make([]string, 0, 2)
+	currentTool := ""
+	runLength := 0
+
+	flush := func() {
+		if currentTool != "" && runLength >= 2 {
+			evidence = append(evidence, fmt.Sprintf("tool_loop=%sx%d", currentTool, runLength))
+		}
+	}
+
+	for _, step := range steps {
+		if step.Tool == "" {
+			flush()
+			currentTool = ""
+			runLength = 0
+			continue
+		}
+		if step.Tool != currentTool {
+			flush()
+			currentTool = step.Tool
+			runLength = 1
+			continue
+		}
+		runLength++
+	}
+	flush()
+
+	return evidence
+}
+
+func dedupeEvidence(evidence []string, limit int) []string {
+	if len(evidence) == 0 {
+		return nil
+	}
+
+	deduped := make([]string, 0, len(evidence))
+	seen := make(map[string]struct{}, len(evidence))
+	for _, item := range evidence {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		deduped = append(deduped, item)
+		if limit > 0 && len(deduped) >= limit {
+			break
+		}
+	}
+
+	return deduped
+}
+
 func truncateString(value string, limit int) string {
-	if limit <= 0 || len(value) <= limit {
+	if limit <= 0 {
+		return ""
+	}
+	if len(value) <= limit {
 		return value
 	}
-	return value[:limit] + "..."
+	if limit <= 3 {
+		return value[:limit]
+	}
+	return value[:limit-3] + "..."
 }
 
 func clamp01(value float64) float64 {

--- a/pkg/agents/optimize/gepa_adapter_test.go
+++ b/pkg/agents/optimize/gepa_adapter_test.go
@@ -133,6 +133,8 @@ func TestGEPAAgentOptimizer_EvaluateCandidateBuildsFitnessAndTraces(t *testing.T
 	assert.False(t, evaluation.Traces[1].Success)
 	assert.Equal(t, "first", evaluation.Traces[0].ContextData["example_id"])
 	assert.Contains(t, evaluation.Traces[0].ContextData, gepaMetadataTraceSummaryKey)
+	assert.Contains(t, evaluation.Traces[0].ContextData, gepaMetadataTraceEvidenceKey)
+	assert.Contains(t, evaluation.Traces[1].ContextData[gepaMetadataTraceEvidenceKey], "failed_test=output:answer")
 	assert.Contains(t, evaluation.Traces[1].ContextData, "diagnostics")
 }
 

--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/rand"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -131,6 +132,7 @@ type ExecutionPatterns struct {
 	AverageResponseTime time.Duration  `json:"average_response_time"`
 	CommonFailures      []string       `json:"common_failures"`
 	QualityIndicators   []string       `json:"quality_indicators"`
+	RichTraceEvidence   []string       `json:"rich_trace_evidence"`
 	ErrorDistribution   map[string]int `json:"error_distribution"`
 	PerformanceTrends   []float64      `json:"performance_trends"`
 }
@@ -4521,16 +4523,19 @@ func (g *GEPA) analyzeExecutionPatterns(traces []ExecutionTrace) *ExecutionPatte
 		return &ExecutionPatterns{
 			ErrorDistribution: make(map[string]int),
 			PerformanceTrends: make([]float64, 0),
+			RichTraceEvidence: make([]string, 0),
 		}
 	}
 
 	patterns := &ExecutionPatterns{
 		ErrorDistribution: make(map[string]int),
 		PerformanceTrends: make([]float64, 0),
+		RichTraceEvidence: make([]string, 0),
 	}
 
 	totalDuration := time.Duration(0)
 	successCount := 0
+	evidenceCounts := make(map[string]int)
 
 	for _, trace := range traces {
 		totalDuration += trace.Duration
@@ -4544,6 +4549,10 @@ func (g *GEPA) analyzeExecutionPatterns(traces []ExecutionTrace) *ExecutionPatte
 				patterns.ErrorDistribution[errorType]++
 			}
 		}
+
+		for _, evidence := range extractRichTraceEvidence(trace) {
+			evidenceCounts[evidence]++
+		}
 	}
 
 	patterns.TotalExecutions = len(traces)
@@ -4552,12 +4561,18 @@ func (g *GEPA) analyzeExecutionPatterns(traces []ExecutionTrace) *ExecutionPatte
 	patterns.AverageResponseTime = totalDuration / time.Duration(len(traces))
 	patterns.CommonFailures = g.identifyCommonFailures(patterns.ErrorDistribution)
 	patterns.QualityIndicators = g.identifyQualityIndicators(patterns.PerformanceTrends)
+	patterns.RichTraceEvidence = topRichTraceEvidence(evidenceCounts, 6)
 
 	return patterns
 }
 
 // buildReflectionPrompt creates a reflection prompt for a candidate.
 func (g *GEPA) buildReflectionPrompt(candidate *GEPACandidate, patterns *ExecutionPatterns) string {
+	richTraceEvidence := "none recorded"
+	if len(patterns.RichTraceEvidence) > 0 {
+		richTraceEvidence = "- " + strings.Join(patterns.RichTraceEvidence, "\n- ")
+	}
+
 	return fmt.Sprintf(`As an expert prompt engineer, critically analyze this instruction and its performance:
 
 INSTRUCTION: "%s"
@@ -4571,11 +4586,14 @@ EXECUTION PATTERNS:
 - Common Failure Modes: %s
 - Quality Indicators: %s
 
+RICH TRACE EVIDENCE:
+%s
+
 Please provide a detailed self-reflection covering:
 
 1. STRENGTHS: What aspects of this instruction work well?
-2. WEAKNESSES: What specific issues limit its effectiveness?
-3. IMPROVEMENT SUGGESTIONS: Concrete ways to enhance this instruction
+2. WEAKNESSES: What specific issues limit its effectiveness? Use the rich trace evidence section to ground concrete failure modes, loops, mismatches, and termination behavior.
+3. IMPROVEMENT SUGGESTIONS: Concrete ways to enhance this instruction based on the execution patterns and rich trace evidence.
 4. CONFIDENCE: Rate your confidence in this analysis (0.0-1.0)
 
 Format your response as:
@@ -4601,7 +4619,8 @@ CONFIDENCE: [0.0-1.0]`,
 		patterns.TotalExecutions,
 		patterns.AverageResponseTime,
 		strings.Join(patterns.CommonFailures, ", "),
-		strings.Join(patterns.QualityIndicators, ", "))
+		strings.Join(patterns.QualityIndicators, ", "),
+		richTraceEvidence)
 }
 
 // parseReflectionResponse parses the LLM reflection response.
@@ -4690,6 +4709,10 @@ func (g *GEPA) createFallbackReflection(candidate *GEPACandidate, patterns *Exec
 		weaknesses = append(weaknesses, fmt.Sprintf("Common failures: %s", strings.Join(patterns.CommonFailures, ", ")))
 		suggestions = append(suggestions, "Address the common failure modes identified")
 	}
+	if len(patterns.RichTraceEvidence) > 0 {
+		weaknesses = append(weaknesses, fmt.Sprintf("Trace evidence: %s", strings.Join(patterns.RichTraceEvidence, "; ")))
+		suggestions = append(suggestions, "Use the trace evidence to target repeated failure loops, mismatches, and termination issues")
+	}
 
 	return &ReflectionResult{
 		CandidateID:     candidate.ID,
@@ -4700,6 +4723,131 @@ func (g *GEPA) createFallbackReflection(candidate *GEPACandidate, patterns *Exec
 		Timestamp:       time.Now(),
 		ReflectionDepth: 1,
 	}
+}
+
+func extractRichTraceEvidence(trace ExecutionTrace) []string {
+	if trace.ContextData == nil {
+		return nil
+	}
+
+	if raw, ok := trace.ContextData["rich_trace_evidence"]; ok {
+		if evidence := dedupeEvidenceLines(evidenceFromValue(raw)); len(evidence) > 0 {
+			return evidence
+		}
+	}
+
+	evidence := make([]string, 0, 8)
+	if termination, ok := trace.ContextData["termination_cause"].(string); ok && strings.TrimSpace(termination) != "" {
+		evidence = append(evidence, "termination="+termination)
+	}
+	if status, ok := trace.ContextData["trace_status"].(string); ok && strings.TrimSpace(status) != "" {
+		evidence = append(evidence, "trace_status="+status)
+	}
+	if failedTests, ok := trace.ContextData["failed_tests"]; ok {
+		for _, item := range evidenceFromValue(failedTests) {
+			evidence = append(evidence, "failed_test="+item)
+		}
+	}
+	if diagnostics, ok := trace.ContextData["diagnostics"].(map[string]interface{}); ok {
+		for _, key := range []string{"evaluation_error", "execution_error", "comparison_error"} {
+			if raw, exists := diagnostics[key]; exists {
+				if message, ok := raw.(string); ok && strings.TrimSpace(message) != "" {
+					evidence = append(evidence, fmt.Sprintf("%s=%s", key, truncateEvidence(message, 100)))
+				}
+			}
+		}
+	}
+	if len(evidence) == 0 {
+		if summary, ok := trace.ContextData["rich_trace_summary"].(string); ok && strings.TrimSpace(summary) != "" {
+			evidence = append(evidence, truncateEvidence(summary, 160))
+		}
+	}
+
+	return dedupeEvidenceLines(evidence)
+}
+
+func evidenceFromValue(raw interface{}) []string {
+	switch value := raw.(type) {
+	case []string:
+		return append([]string(nil), value...)
+	case []interface{}:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			if str, ok := item.(string); ok && strings.TrimSpace(str) != "" {
+				result = append(result, str)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func topRichTraceEvidence(counts map[string]int, limit int) []string {
+	if len(counts) == 0 {
+		return []string{}
+	}
+
+	type countedEvidence struct {
+		evidence string
+		count    int
+	}
+
+	items := make([]countedEvidence, 0, len(counts))
+	for evidence, count := range counts {
+		if strings.TrimSpace(evidence) == "" {
+			continue
+		}
+		items = append(items, countedEvidence{evidence: evidence, count: count})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].count == items[j].count {
+			return items[i].evidence < items[j].evidence
+		}
+		return items[i].count > items[j].count
+	})
+
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, fmt.Sprintf("%s (seen %dx)", item.evidence, item.count))
+	}
+	return result
+}
+
+func dedupeEvidenceLines(lines []string) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	result := make([]string, 0, len(lines))
+	seen := make(map[string]struct{}, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if _, exists := seen[line]; exists {
+			continue
+		}
+		seen[line] = struct{}{}
+		result = append(result, line)
+	}
+	return result
+}
+
+func truncateEvidence(value string, limit int) string {
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	if limit <= 3 {
+		return value[:limit]
+	}
+	return value[:limit-3] + "..."
 }
 
 // Helper methods for reflection analysis

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -2,6 +2,7 @@ package optimizers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -707,6 +708,51 @@ func TestReflectionEngine(t *testing.T) {
 	reflection, err := gepa.reflectOnCandidate(ctx, candidate, traces)
 	require.NoError(t, err)
 	assert.Equal(t, candidate.ID, reflection.CandidateID)
+}
+
+func TestReflectionEngine_UsesRichTraceEvidence(t *testing.T) {
+	mockLLM := &testutil.MockLLM{}
+	setupGEPAMockLLM(mockLLM)
+	core.SetDefaultLLM(mockLLM)
+
+	gepa, err := NewGEPA(DefaultGEPAConfig())
+	require.NoError(t, err)
+
+	candidate := &GEPACandidate{
+		ID:          "rich-trace-candidate",
+		ModuleName:  "skill_pack",
+		Instruction: "Use the repository debugging guide.",
+		Fitness:     0.6,
+		Generation:  1,
+	}
+
+	traces := []ExecutionTrace{
+		{
+			CandidateID: candidate.ID,
+			Success:     false,
+			Duration:    150 * time.Millisecond,
+			Error:       fmt.Errorf("comparison failed"),
+			ContextData: map[string]interface{}{
+				"rich_trace_evidence": []string{
+					"termination=max_iterations",
+					"failed_test=output:answer",
+				},
+				"termination_cause": "max_iterations",
+				"failed_tests":      []string{"output:answer"},
+			},
+		},
+	}
+
+	patterns := gepa.analyzeExecutionPatterns(traces)
+	require.NotNil(t, patterns)
+	assert.Len(t, patterns.RichTraceEvidence, 2)
+	assert.Contains(t, patterns.RichTraceEvidence, "termination=max_iterations (seen 1x)")
+	assert.Contains(t, patterns.RichTraceEvidence, "failed_test=output:answer (seen 1x)")
+
+	prompt := gepa.buildReflectionPrompt(candidate, patterns)
+	assert.Contains(t, prompt, "RICH TRACE EVIDENCE:")
+	assert.Contains(t, prompt, "termination=max_iterations (seen 1x)")
+	assert.Contains(t, prompt, "failed_test=output:answer (seen 1x)")
 }
 
 func TestSelfCritiqueSystem(t *testing.T) {


### PR DESCRIPTION
## Summary
- add structured rich-trace evidence to GEPA adapter traces alongside the existing summary string
- teach GEPA reflection analysis and prompt construction to consume rich trace evidence instead of only flat success/error aggregates
- add regression tests for adapter evidence emission and reflection prompt evidence usage

Closes #210

## Validation
- go test ./pkg/agents/optimize ./pkg/optimizers
- go test ./pkg/agents/react
- golangci-lint run ./...