### PR TITLE
agents: add GEPA-ready RLM agent optimization

### DIFF
--- a/pkg/agents/optimize/artifacts.go
+++ b/pkg/agents/optimize/artifacts.go
@@ -6,12 +6,14 @@ import "github.com/XiaoConstantine/dspy-go/pkg/agents"
 type ArtifactKey string
 
 const (
-	ArtifactSkillPack        ArtifactKey = "skill_pack"
-	ArtifactPlannerPrompt    ArtifactKey = "planner_prompt"
-	ArtifactToolPolicy       ArtifactKey = "tool_policy"
-	ArtifactMemoryTemplate   ArtifactKey = "memory_template"
-	ArtifactReflectionPrompt ArtifactKey = "reflection_prompt"
-	ArtifactContextPolicy    ArtifactKey = "context_policy"
+	ArtifactSkillPack          ArtifactKey = "skill_pack"
+	ArtifactPlannerPrompt      ArtifactKey = "planner_prompt"
+	ArtifactToolPolicy         ArtifactKey = "tool_policy"
+	ArtifactMemoryTemplate     ArtifactKey = "memory_template"
+	ArtifactReflectionPrompt   ArtifactKey = "reflection_prompt"
+	ArtifactContextPolicy      ArtifactKey = "context_policy"
+	ArtifactRLMOuterPrompt     ArtifactKey = "rlm_outer_prompt"
+	ArtifactRLMIterationPrompt ArtifactKey = "rlm_iteration_prompt"
 )
 
 // AgentArtifacts groups mutable agent configuration surfaced to optimizers.

--- a/pkg/agents/rlm/agent.go
+++ b/pkg/agents/rlm/agent.go
@@ -1,0 +1,352 @@
+package rlm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/agents/optimize"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	modrlm "github.com/XiaoConstantine/dspy-go/pkg/modules/rlm"
+)
+
+const (
+	ArtifactMaxIterations            = "rlm_max_iterations"
+	ArtifactMaxTokens                = "rlm_max_tokens"
+	ArtifactUseIterationDemos        = "rlm_use_iteration_demos"
+	ArtifactCompactIterationPrompt   = "rlm_compact_iteration_instructions"
+	ArtifactAdaptiveIterationEnabled = "rlm_adaptive_iteration_enabled"
+	defaultAgentIDPrefix             = "rlm-agent"
+	agentTypeRLM                     = "rlm"
+)
+
+// Agent wraps an RLM module with the agents.Agent and optimize.OptimizableAgent contracts.
+type Agent struct {
+	id        string
+	module    *modrlm.RLM
+	memory    agents.Memory
+	artifacts optimize.AgentArtifacts
+	lastTrace *agents.ExecutionTrace
+	mu        sync.RWMutex
+}
+
+var _ optimize.OptimizableAgent = (*Agent)(nil)
+
+// NewAgent creates an optimizable agent around an RLM module.
+func NewAgent(id string, module *modrlm.RLM) *Agent {
+	if strings.TrimSpace(id) == "" {
+		id = fmt.Sprintf("%s-%d", defaultAgentIDPrefix, time.Now().UnixNano())
+	}
+
+	agent := &Agent{
+		id:     id,
+		module: module,
+	}
+	if module != nil {
+		agent.artifacts = artifactsFromConfig(module.Config())
+	}
+	return agent
+}
+
+// Execute runs the wrapped RLM module and records the most recent execution trace.
+func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	if a == nil {
+		err := fmt.Errorf("rlm agent is not initialized")
+		return nil, err
+	}
+	if a.module == nil {
+		err := fmt.Errorf("rlm agent is not initialized")
+		a.storeTrace(buildMinimalFailureTrace("", input, err))
+		return nil, err
+	}
+
+	contextPayload, ok := input["context"]
+	if !ok {
+		err := modrlm.ErrMissingContext
+		a.storeTrace(buildMinimalFailureTrace(a.id, input, err))
+		return nil, err
+	}
+	query, ok := input["query"].(string)
+	if !ok {
+		err := modrlm.ErrMissingQuery
+		a.storeTrace(buildMinimalFailureTrace(a.id, input, err))
+		return nil, err
+	}
+
+	result, trace, err := a.module.CompleteWithTrace(ctx, contextPayload, query)
+
+	output := map[string]interface{}{}
+	if result != nil {
+		output["answer"] = result.Response
+	}
+
+	a.storeTrace(a.buildExecutionTrace(input, output, err, trace))
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+// GetCapabilities returns nil because the RLM-backed agent does not expose tool capabilities through the agent interface.
+func (a *Agent) GetCapabilities() []core.Tool {
+	return nil
+}
+
+// GetMemory returns the configured memory store, if any.
+func (a *Agent) GetMemory() agents.Memory {
+	if a == nil {
+		return nil
+	}
+	return a.memory
+}
+
+// GetArtifacts returns a defensive copy of the current artifact set.
+func (a *Agent) GetArtifacts() optimize.AgentArtifacts {
+	if a == nil {
+		return optimize.AgentArtifacts{}
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.artifacts.Clone()
+}
+
+// SetArtifacts applies a full artifact set to the wrapped RLM module.
+func (a *Agent) SetArtifacts(artifacts optimize.AgentArtifacts) error {
+	if a == nil || a.module == nil {
+		return fmt.Errorf("rlm agent is not initialized")
+	}
+
+	cfg := a.module.Config()
+	applyArtifactsToConfig(&cfg, artifacts)
+	a.module.SetConfig(cfg)
+
+	a.mu.Lock()
+	a.artifacts = artifactsFromConfig(cfg)
+	a.mu.Unlock()
+
+	return nil
+}
+
+// Clone returns a clone-safe copy of the agent and the wrapped RLM module.
+func (a *Agent) Clone() (optimize.OptimizableAgent, error) {
+	if a == nil || a.module == nil {
+		return nil, fmt.Errorf("rlm agent is not initialized")
+	}
+
+	clonedModule, ok := a.module.Clone().(*modrlm.RLM)
+	if !ok {
+		return nil, fmt.Errorf("rlm agent clone produced unexpected module type")
+	}
+
+	cloned := &Agent{
+		id:     a.id,
+		module: clonedModule,
+		// Memory is intentionally shared because agents.Memory has no clone contract today.
+		// This mirrors existing agent behavior and keeps the wrapper compatible with stateful stores.
+		memory:    a.memory,
+		artifacts: a.GetArtifacts(),
+	}
+	if trace := a.LastExecutionTrace(); trace != nil {
+		cloned.lastTrace = trace
+	}
+	return cloned, nil
+}
+
+// LastExecutionTrace returns the most recent execution trace, if any.
+func (a *Agent) LastExecutionTrace() *agents.ExecutionTrace {
+	if a == nil {
+		return nil
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.lastTrace.Clone()
+}
+
+func (a *Agent) storeTrace(trace *agents.ExecutionTrace) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.lastTrace = trace
+}
+
+func (a *Agent) buildExecutionTrace(input map[string]interface{}, output map[string]interface{}, err error, trace *modrlm.RLMTrace) *agents.ExecutionTrace {
+	if trace == nil {
+		return buildMinimalFailureTrace(a.id, input, err)
+	}
+
+	steps := make([]agents.TraceStep, 0, len(trace.Steps))
+	toolUsageCount := make(map[string]int)
+	status := agents.TraceStatusSuccess
+
+	for _, step := range trace.Steps {
+		toolName := ""
+		if step.Action != "" && step.Action != "final" {
+			toolName = step.Action
+			toolUsageCount[toolName]++
+		}
+		if !step.Success && status == agents.TraceStatusSuccess {
+			status = agents.TraceStatusPartial
+		}
+
+		steps = append(steps, agents.TraceStep{
+			Index:       step.Index,
+			Thought:     step.Thought,
+			ActionRaw:   step.Action,
+			Tool:        toolName,
+			Observation: step.Observation,
+			Duration:    step.Duration,
+			Success:     step.Success,
+			Error:       step.Error,
+		})
+	}
+
+	if err != nil {
+		status = agents.TraceStatusFailure
+	}
+
+	tokenUsage := map[string]int64{
+		"prompt_tokens":     int64(trace.Usage.PromptTokens),
+		"completion_tokens": int64(trace.Usage.CompletionTokens),
+		"total_tokens":      int64(trace.Usage.TotalTokens),
+	}
+
+	contextMetadata := map[string]interface{}{
+		"iterations":                     trace.Iterations,
+		"termination_cause":              trace.TerminationCause,
+		"adaptive_iteration_enabled":     a.artifacts.Bool[ArtifactAdaptiveIterationEnabled],
+		"compact_iteration_instructions": a.artifacts.Bool[ArtifactCompactIterationPrompt],
+		"use_iteration_demos":            a.artifacts.Bool[ArtifactUseIterationDemos],
+		"max_iterations":                 a.artifacts.Int[ArtifactMaxIterations],
+		"max_tokens":                     a.artifacts.Int[ArtifactMaxTokens],
+	}
+
+	executionTrace := &agents.ExecutionTrace{
+		AgentID:          a.id,
+		AgentType:        agentTypeRLM,
+		Task:             inputString(input, "query"),
+		Input:            core.ShallowCopyMap(input),
+		Output:           core.ShallowCopyMap(output),
+		Steps:            steps,
+		Status:           status,
+		StartedAt:        trace.StartedAt,
+		CompletedAt:      trace.CompletedAt,
+		ProcessingTime:   trace.ProcessingTime,
+		TokenUsage:       tokenUsage,
+		ToolUsageCount:   toolUsageCount,
+		ContextMetadata:  contextMetadata,
+		TerminationCause: trace.TerminationCause,
+	}
+	if err != nil {
+		executionTrace.Error = err.Error()
+	} else if trace.Error != "" {
+		executionTrace.Error = trace.Error
+	}
+
+	return executionTrace
+}
+
+func buildMinimalFailureTrace(agentID string, input map[string]interface{}, err error) *agents.ExecutionTrace {
+	trace := &agents.ExecutionTrace{
+		AgentID:          agentID,
+		AgentType:        agentTypeRLM,
+		Task:             inputString(input, "query"),
+		Input:            core.ShallowCopyMap(input),
+		Output:           map[string]interface{}{},
+		Status:           agents.TraceStatusFailure,
+		StartedAt:        time.Now(),
+		CompletedAt:      time.Now(),
+		ProcessingTime:   0,
+		ToolUsageCount:   map[string]int{},
+		ContextMetadata:  map[string]interface{}{},
+		TerminationCause: "error",
+	}
+	if err != nil {
+		trace.Error = err.Error()
+	}
+	return trace
+}
+
+func inputString(input map[string]interface{}, key string) string {
+	if input == nil {
+		return ""
+	}
+	raw, ok := input[key]
+	if !ok {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func artifactsFromConfig(cfg modrlm.Config) optimize.AgentArtifacts {
+	artifacts := optimize.AgentArtifacts{
+		Text: map[optimize.ArtifactKey]string{
+			optimize.ArtifactRLMOuterPrompt:     cfg.OuterInstruction,
+			optimize.ArtifactRLMIterationPrompt: cfg.IterationInstruction,
+		},
+		Int: map[string]int{
+			ArtifactMaxIterations: cfg.MaxIterations,
+			ArtifactMaxTokens:     cfg.MaxTokens,
+		},
+		Bool: map[string]bool{
+			ArtifactUseIterationDemos:        cfg.UseIterationDemos,
+			ArtifactCompactIterationPrompt:   cfg.CompactIterationInstructions,
+			ArtifactAdaptiveIterationEnabled: cfg.AdaptiveIteration != nil && cfg.AdaptiveIteration.Enabled,
+		},
+	}
+
+	if artifacts.Text[optimize.ArtifactRLMOuterPrompt] == "" {
+		artifacts.Text[optimize.ArtifactRLMOuterPrompt] = modrlm.DefaultOuterInstruction()
+	}
+	if artifacts.Text[optimize.ArtifactRLMIterationPrompt] == "" {
+		artifacts.Text[optimize.ArtifactRLMIterationPrompt] = modrlm.DefaultIterationInstruction(cfg.CompactIterationInstructions)
+	}
+
+	return artifacts
+}
+
+func applyArtifactsToConfig(cfg *modrlm.Config, artifacts optimize.AgentArtifacts) {
+	if cfg == nil {
+		return
+	}
+
+	if value, ok := artifacts.Text[optimize.ArtifactRLMOuterPrompt]; ok && strings.TrimSpace(value) != "" {
+		cfg.OuterInstruction = value
+	}
+	if value, ok := artifacts.Text[optimize.ArtifactRLMIterationPrompt]; ok && strings.TrimSpace(value) != "" {
+		cfg.IterationInstruction = value
+	}
+
+	if value, ok := artifacts.Int[ArtifactMaxIterations]; ok && value > 0 {
+		cfg.MaxIterations = value
+	}
+	if value, ok := artifacts.Int[ArtifactMaxTokens]; ok && value >= 0 {
+		cfg.MaxTokens = value
+	}
+
+	if value, ok := artifacts.Bool[ArtifactUseIterationDemos]; ok {
+		cfg.UseIterationDemos = value
+	}
+	if value, ok := artifacts.Bool[ArtifactCompactIterationPrompt]; ok {
+		cfg.CompactIterationInstructions = value
+	}
+	if value, ok := artifacts.Bool[ArtifactAdaptiveIterationEnabled]; ok {
+		if value {
+			if cfg.AdaptiveIteration == nil {
+				defaultAdaptive := modrlm.DefaultAdaptiveIterationConfig()
+				cfg.AdaptiveIteration = &defaultAdaptive
+			} else {
+				cfg.AdaptiveIteration.Enabled = true
+			}
+		} else {
+			cfg.AdaptiveIteration = nil
+		}
+	}
+}

--- a/pkg/agents/rlm/agent_test.go
+++ b/pkg/agents/rlm/agent_test.go
@@ -1,0 +1,208 @@
+package rlm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/agents/optimize"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	modrlm "github.com/XiaoConstantine/dspy-go/pkg/modules/rlm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testLLM struct {
+	responses []string
+	callCount int
+}
+
+func (m *testLLM) Generate(ctx context.Context, prompt string, opts ...core.GenerateOption) (*core.LLMResponse, error) {
+	if m.callCount >= len(m.responses) {
+		return nil, fmt.Errorf("no more mock responses")
+	}
+	response := m.responses[m.callCount]
+	m.callCount++
+	return &core.LLMResponse{
+		Content: response,
+		Usage: &core.TokenInfo{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			TotalTokens:      150,
+		},
+	}, nil
+}
+
+func (m *testLLM) GenerateWithJSON(context.Context, string, ...core.GenerateOption) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *testLLM) GenerateWithFunctions(context.Context, string, []map[string]interface{}, ...core.GenerateOption) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *testLLM) GenerateWithContent(ctx context.Context, content []core.ContentBlock, opts ...core.GenerateOption) (*core.LLMResponse, error) {
+	return m.Generate(ctx, "", opts...)
+}
+
+func (m *testLLM) StreamGenerate(context.Context, string, ...core.GenerateOption) (*core.StreamResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *testLLM) StreamGenerateWithContent(context.Context, []core.ContentBlock, ...core.GenerateOption) (*core.StreamResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *testLLM) CreateEmbedding(context.Context, string, ...core.EmbeddingOption) (*core.EmbeddingResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *testLLM) CreateEmbeddings(context.Context, []string, ...core.EmbeddingOption) (*core.BatchEmbeddingResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *testLLM) ProviderName() string { return "mock" }
+func (m *testLLM) ModelID() string      { return "mock-model" }
+func (m *testLLM) Capabilities() []core.Capability {
+	return []core.Capability{core.CapabilityCompletion}
+}
+
+type testAgentEvaluator func(ctx context.Context, agent optimize.OptimizableAgent, ex optimize.AgentExample) (*optimize.EvalResult, error)
+
+func (f testAgentEvaluator) Evaluate(ctx context.Context, agent optimize.OptimizableAgent, ex optimize.AgentExample) (*optimize.EvalResult, error) {
+	return f(ctx, agent, ex)
+}
+
+func TestAgentExecute_RecordsTraceAndOutput(t *testing.T) {
+	module := modrlm.NewFromLLM(&testLLM{
+		responses: []string{
+			"Reasoning:\nI'll answer directly.\n\nAction:\nfinal\n\nCode:\n\nAnswer:\n42",
+		},
+	}, modrlm.WithMaxIterations(1))
+
+	agent := NewAgent("adaptive-rlm", module)
+	output, err := agent.Execute(context.Background(), map[string]interface{}{
+		"context": "ctx",
+		"query":   "what is the answer?",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "42", output["answer"])
+
+	trace := agent.LastExecutionTrace()
+	require.NotNil(t, trace)
+	assert.Equal(t, "adaptive-rlm", trace.AgentID)
+	assert.Equal(t, "rlm", trace.AgentType)
+	assert.Equal(t, "what is the answer?", trace.Task)
+	assert.Equal(t, agents.TraceStatusSuccess, trace.Status)
+	assert.Equal(t, "final_answer", trace.TerminationCause)
+	require.Len(t, trace.Steps, 1)
+	assert.Equal(t, "final", trace.Steps[0].ActionRaw)
+}
+
+func TestAgentExecute_NilReceiverReturnsError(t *testing.T) {
+	var agent *Agent
+	_, err := agent.Execute(context.Background(), map[string]interface{}{
+		"context": "ctx",
+		"query":   "what is the answer?",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not initialized")
+}
+
+func TestAgentSetArtifacts_AppliesRLMConfig(t *testing.T) {
+	module := modrlm.NewFromLLM(&testLLM{
+		responses: []string{
+			"Reasoning:\nDone.\n\nAction:\nfinal\n\nCode:\n\nAnswer:\ncomplete",
+		},
+	})
+	agent := NewAgent("adaptive-rlm", module)
+
+	err := agent.SetArtifacts(optimize.AgentArtifacts{
+		Text: map[optimize.ArtifactKey]string{
+			optimize.ArtifactRLMOuterPrompt:     "Custom outer prompt.",
+			optimize.ArtifactRLMIterationPrompt: "Custom iteration prompt.",
+		},
+		Int: map[string]int{
+			ArtifactMaxIterations: 7,
+			ArtifactMaxTokens:     900,
+		},
+		Bool: map[string]bool{
+			ArtifactUseIterationDemos:        true,
+			ArtifactCompactIterationPrompt:   false,
+			ArtifactAdaptiveIterationEnabled: true,
+		},
+	})
+	require.NoError(t, err)
+
+	cfg := module.Config()
+	assert.Equal(t, "Custom outer prompt.", cfg.OuterInstruction)
+	assert.Equal(t, "Custom iteration prompt.", cfg.IterationInstruction)
+	assert.Equal(t, 7, cfg.MaxIterations)
+	assert.Equal(t, 900, cfg.MaxTokens)
+	assert.True(t, cfg.UseIterationDemos)
+	require.NotNil(t, cfg.AdaptiveIteration)
+	assert.True(t, cfg.AdaptiveIteration.Enabled)
+}
+
+func TestGEPAAgentOptimizer_Optimize_RLMIterationPrompt(t *testing.T) {
+	mutationLLM := &testLLM{
+		responses: []string{
+			"1. Carefully inspect the context before deciding.\n2. Verify the answer before returning it.\n3. Keep the loop disciplined.",
+		},
+	}
+	originalDefault := core.GetDefaultLLM()
+	originalTeacher := core.GetTeacherLLM()
+	core.SetDefaultLLM(mutationLLM)
+	core.GlobalConfig.TeacherLLM = mutationLLM
+	t.Cleanup(func() {
+		core.SetDefaultLLM(originalDefault)
+		core.GlobalConfig.TeacherLLM = originalTeacher
+	})
+
+	baseAgent := NewAgent("adaptive-rlm", modrlm.NewFromLLM(&testLLM{
+		responses: []string{
+			"Reasoning:\nDone.\n\nAction:\nfinal\n\nCode:\n\nAnswer:\ncomplete",
+		},
+	}))
+
+	optimizer := optimize.NewGEPAAgentOptimizer(
+		baseAgent,
+		testAgentEvaluator(func(ctx context.Context, agent optimize.OptimizableAgent, ex optimize.AgentExample) (*optimize.EvalResult, error) {
+			prompt := strings.ToLower(agent.GetArtifacts().Text[optimize.ArtifactRLMIterationPrompt])
+			score := 0.2
+			if strings.Contains(prompt, "carefully") {
+				score = 1.0
+			}
+			return &optimize.EvalResult{
+				Score: score,
+				SideInfo: &optimize.SideInfo{
+					Scores: map[string]float64{"prompt_fit": score},
+					Diagnostics: map[string]interface{}{
+						"artifact": "rlm_iteration_prompt",
+					},
+				},
+			}, nil
+		}),
+		optimize.GEPAAdapterConfig{
+			PopulationSize:  3,
+			MaxGenerations:  1,
+			ReflectionFreq:  0,
+			ValidationSplit: 0,
+			EvalConcurrency: 1,
+			PassThreshold:   0.5,
+			PrimaryArtifact: optimize.ArtifactRLMIterationPrompt,
+		},
+	)
+
+	result, err := optimizer.Optimize(context.Background(), optimize.GEPAOptimizeRequest{
+		SeedArtifacts: baseAgent.GetArtifacts(),
+		TrainingExamples: []optimize.AgentExample{
+			{ID: "train-1"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, strings.ToLower(result.BestArtifacts.Text[optimize.ArtifactRLMIterationPrompt]), "carefully")
+}

--- a/pkg/agents/skills/store.go
+++ b/pkg/agents/skills/store.go
@@ -76,8 +76,8 @@ func (s *MemoryStore) Load(ctx context.Context, domain string) ([]Skill, error) 
 		return []Skill{}, nil
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	return filterAndSortSkills(s.skills, normalizedDomain), nil
 }

--- a/pkg/modules/rlm/config.go
+++ b/pkg/modules/rlm/config.go
@@ -7,6 +7,14 @@ import "time"
 
 // Config holds RLM configuration.
 type Config struct {
+	// OuterInstruction overrides the top-level RLM module instruction.
+	// Empty string uses the default outer instruction.
+	OuterInstruction string
+
+	// IterationInstruction overrides the iteration module instruction.
+	// Empty string uses the compact/full built-in instruction based on config.
+	IterationInstruction string
+
 	// MaxIterations is the maximum number of iteration loops (default: 30).
 	MaxIterations int
 
@@ -161,6 +169,8 @@ type IterationProgress struct {
 // DefaultConfig returns the default RLM configuration.
 func DefaultConfig() Config {
 	return Config{
+		OuterInstruction:             "",
+		IterationInstruction:         "",
 		MaxIterations:                30,
 		MaxTokens:                    0,
 		Verbose:                      false,
@@ -170,6 +180,39 @@ func DefaultConfig() Config {
 		CompactIterationInstructions: true,
 		OutputTruncation:             outputTruncationConfigPtr(DefaultOutputTruncationConfig()),
 	}
+}
+
+// DefaultAdaptiveIterationConfig returns the built-in adaptive iteration policy.
+func DefaultAdaptiveIterationConfig() AdaptiveIterationConfig {
+	return AdaptiveIterationConfig{
+		Enabled:                true,
+		BaseIterations:         10,
+		MaxIterations:          50,
+		ContextScaleFactor:     100000,
+		EnableEarlyTermination: true,
+		ConfidenceThreshold:    1,
+	}
+}
+
+func cloneConfig(cfg Config) Config {
+	cloned := cfg
+	if cfg.HistoryCompression != nil {
+		history := *cfg.HistoryCompression
+		cloned.HistoryCompression = &history
+	}
+	if cfg.AdaptiveIteration != nil {
+		adaptive := *cfg.AdaptiveIteration
+		cloned.AdaptiveIteration = &adaptive
+	}
+	if cfg.SubRLM != nil {
+		sub := *cfg.SubRLM
+		cloned.SubRLM = &sub
+	}
+	if cfg.OutputTruncation != nil {
+		output := *cfg.OutputTruncation
+		cloned.OutputTruncation = &output
+	}
+	return cloned
 }
 
 // Option configures the RLM.
@@ -256,14 +299,8 @@ func WithHistoryCompression(verbatimIterations, maxSummaryTokens int) Option {
 // early termination when the model signals confidence.
 func WithAdaptiveIteration() Option {
 	return func(c *Config) {
-		c.AdaptiveIteration = &AdaptiveIterationConfig{
-			Enabled:                true,
-			BaseIterations:         10,
-			MaxIterations:          50,
-			ContextScaleFactor:     100000, // 100KB per additional iteration
-			EnableEarlyTermination: true,
-			ConfidenceThreshold:    1,
-		}
+		cfg := DefaultAdaptiveIterationConfig()
+		c.AdaptiveIteration = &cfg
 	}
 }
 

--- a/pkg/modules/rlm/rlm.go
+++ b/pkg/modules/rlm/rlm.go
@@ -150,9 +150,10 @@ func New(rootLLM core.LLM, subLLMClient SubLLMClient, opts ...Option) *RLM {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	cfg = cloneConfig(cfg)
 
 	// Create the main RLM signature using the DSPy-native signature
-	signature := RLMSignature()
+	signature := RLMSignatureWithInstruction(resolveOuterInstruction(cfg))
 
 	baseModule := core.NewModule(signature)
 	baseModule.ModuleType = "RLM"
@@ -171,10 +172,11 @@ func New(rootLLM core.LLM, subLLMClient SubLLMClient, opts ...Option) *RLM {
 
 // WithOptions applies additional options to the RLM module.
 func (r *RLM) WithOptions(opts ...Option) *RLM {
+	cfg := cloneConfig(r.config)
 	for _, opt := range opts {
-		opt(&r.config)
+		opt(&cfg)
 	}
-	r.rebuildIterationModule()
+	r.SetConfig(cfg)
 	return r
 }
 
@@ -185,11 +187,26 @@ func (r *RLM) SetLLM(llm core.LLM) {
 	r.rebuildIterationModule()
 }
 
-func buildIterationModule(rootLLM core.LLM, cfg Config) *modules.Predict {
-	signature := IterationSignature()
-	if cfg.CompactIterationInstructions {
-		signature = CompactIterationSignature()
+// Config returns a defensive copy of the current RLM configuration.
+func (r *RLM) Config() Config {
+	if r == nil {
+		return DefaultConfig()
 	}
+	return cloneConfig(r.config)
+}
+
+// SetConfig applies a new RLM configuration and rebuilds prompt-bearing internals.
+func (r *RLM) SetConfig(cfg Config) {
+	if r == nil {
+		return
+	}
+	r.config = cloneConfig(cfg)
+	r.BaseModule.SetSignature(RLMSignatureWithInstruction(resolveOuterInstruction(r.config)))
+	r.rebuildIterationModule()
+}
+
+func buildIterationModule(rootLLM core.LLM, cfg Config) *modules.Predict {
+	signature := iterationSignatureWithInstruction(resolveIterationInstruction(cfg))
 
 	iterMod := modules.NewPredict(signature).WithTextOutput()
 	if cfg.UseIterationDemos {
@@ -205,6 +222,20 @@ func (r *RLM) rebuildIterationModule() {
 		return
 	}
 	r.iterationModule = buildIterationModule(r.rootLLM, r.config)
+}
+
+func resolveOuterInstruction(cfg Config) string {
+	if cfg.OuterInstruction != "" {
+		return cfg.OuterInstruction
+	}
+	return DefaultOuterInstruction()
+}
+
+func resolveIterationInstruction(cfg Config) string {
+	if cfg.IterationInstruction != "" {
+		return cfg.IterationInstruction
+	}
+	return DefaultIterationInstruction(cfg.CompactIterationInstructions)
 }
 
 // ProcessWithInterceptors executes the RLM module's logic with interceptor support.
@@ -233,7 +264,7 @@ func (r *RLM) Process(ctx context.Context, inputs map[string]any, opts ...core.O
 	logger.Debug(ctx, "Starting RLM completion with query: %s", query)
 
 	// Run the completion
-	result, err := r.Complete(ctx, contextPayload, query)
+	result, _, err := r.CompleteWithTrace(ctx, contextPayload, query)
 	if err != nil {
 		span.WithError(err)
 		return nil, err
@@ -260,8 +291,21 @@ func (r *RLM) Process(ctx context.Context, inputs map[string]any, opts ...core.O
 // contextPayload is the context data (string, map, or slice).
 // query is the user's question.
 func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*CompletionResult, error) {
+	result, _, err := r.CompleteWithTrace(ctx, contextPayload, query)
+	return result, err
+}
+
+// CompleteWithTrace runs an RLM completion and returns a structured trace of the execution.
+func (r *RLM) CompleteWithTrace(ctx context.Context, contextPayload any, query string) (*CompletionResult, *RLMTrace, error) {
 	logger := logging.GetLogger()
 	start := time.Now()
+	trace := &RLMTrace{
+		Input: map[string]any{
+			"context": contextPayload,
+			"query":   query,
+		},
+		StartedAt: start,
+	}
 
 	ctx = core.WithExecutionState(ctx)
 
@@ -305,18 +349,23 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 	// Create REPL environment
 	replEnv, err := NewYaegiREPL(r.subLLMClient)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create REPL: %w", err)
+		finalizeRLMTrace(trace, nil, "repl_create_error", fmt.Errorf("failed to create REPL: %w", err))
+		return nil, trace, fmt.Errorf("failed to create REPL: %w", err)
 	}
 
 	// Load context into REPL
 	if err := replEnv.LoadContext(contextPayload); err != nil {
-		return nil, fmt.Errorf("failed to load context: %w", err)
+		loadErr := fmt.Errorf("failed to load context: %w", err)
+		finalizeRLMTrace(trace, nil, "context_load_error", loadErr)
+		return nil, trace, loadErr
 	}
 
 	// Allow callers to extend the REPL before the iteration loop starts.
 	if r.config.REPLSetup != nil {
 		if err := r.config.REPLSetup(replEnv); err != nil {
-			return nil, fmt.Errorf("REPL setup hook failed: %w", err)
+			setupErr := fmt.Errorf("REPL setup hook failed: %w", err)
+			finalizeRLMTrace(trace, nil, "repl_setup_error", setupErr)
+			return nil, trace, setupErr
 		}
 	}
 
@@ -336,11 +385,19 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			trace.CompletedAt = time.Now()
+			trace.ProcessingTime = time.Since(start)
+			trace.TerminationCause = "context_canceled"
+			trace.Error = ctx.Err().Error()
+			return nil, trace, ctx.Err()
 		default:
 		}
 		if err := r.enforceTokenBudget(); err != nil {
-			return nil, err
+			trace.CompletedAt = time.Now()
+			trace.ProcessingTime = time.Since(start)
+			trace.TerminationCause = "token_budget_exceeded"
+			trace.Error = err.Error()
+			return nil, trace, err
 		}
 
 		if r.config.Verbose {
@@ -358,7 +415,9 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 		// Call the iteration module
 		outputs, err := r.iterationModule.Process(ctx, iterInputs)
 		if err != nil {
-			return nil, fmt.Errorf("iteration %d: module process failed: %w", i, err)
+			processErr := fmt.Errorf("iteration %d: module process failed: %w", i, err)
+			finalizeRLMTrace(trace, nil, "iteration_process_error", processErr)
+			return nil, trace, processErr
 		}
 
 		// Extract structured outputs
@@ -373,7 +432,8 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 
 		rootPromptTokens := r.trackTokenUsage(ctx, i+1)
 		if err := r.enforceTokenBudget(); err != nil {
-			return nil, err
+			finalizeRLMTrace(trace, nil, "token_budget_exceeded", err)
+			return nil, trace, err
 		}
 
 		// Report progress after the LLM call so per-iteration prompt tokens are available
@@ -401,10 +461,12 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 			if err != nil {
 				logger.Warn(ctx, "[RLM] Sub-RLM execution error: %v", err)
 				r.appendIterationHistory(&history, i+1, action, reasoning, "", fmt.Sprintf("Sub-RLM error: %v", err))
+				trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, "", subquery, "", fmt.Sprintf("Sub-RLM error: %v", err), time.Since(iterStart), false, err))
 			} else {
 				// Store result in REPL variable for access in subsequent iterations
 				_ = replEnv.SetVariable("subrlm_result", subRLMResult)
 				r.appendIterationHistory(&history, i+1, action, reasoning, "", fmt.Sprintf("Sub-RLM completed: %s", subRLMResult))
+				trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, "", subquery, fmt.Sprintf("Sub-RLM completed: %s", subRLMResult), "", time.Since(iterStart), true, nil))
 
 				if r.config.Verbose {
 					logger.Debug(ctx, "[RLM] Sub-RLM result: %s", utils.TruncateString(subRLMResult, truncateLenMedium))
@@ -454,13 +516,16 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 						time.Since(iterStart),
 					)
 				}
+				trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, code, subquery, finalAnswer, "", time.Since(iterStart), true, nil))
 
-				return &CompletionResult{
+				result := &CompletionResult{
 					Response:   finalAnswer,
 					Iterations: i + 1,
 					Duration:   time.Since(start),
 					Usage:      r.tokenTracker.GetTotalUsage(),
-				}, nil
+				}
+				finalizeRLMTrace(trace, result, "final_answer", nil)
+				return result, trace, nil
 			}
 		}
 
@@ -500,7 +565,11 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 				fullExecOutput += fmt.Sprintf("\n\n[LLM query]\n%s\n[LLM result]\n%s", call.Prompt, call.Response)
 			}
 			if err := r.enforceTokenBudget(); err != nil {
-				return nil, err
+				trace.CompletedAt = time.Now()
+				trace.ProcessingTime = time.Since(start)
+				trace.TerminationCause = "token_budget_exceeded"
+				trace.Error = err.Error()
+				return nil, trace, err
 			}
 
 			callSummary := r.summarizeLLMCalls(llmCalls)
@@ -533,13 +602,16 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 						time.Since(iterStart),
 					)
 				}
+				trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, code, subquery, resultResponse, "", time.Since(iterStart), execErr == nil, execErr))
 
-				return &CompletionResult{
+				completion := &CompletionResult{
 					Response:   resultResponse,
 					Iterations: i + 1,
 					Duration:   time.Since(start),
 					Usage:      r.tokenTracker.GetTotalUsage(),
-				}, nil
+				}
+				finalizeRLMTrace(trace, completion, "state_final", nil)
+				return completion, trace, nil
 			}
 
 			// Fallback: Check for FINAL in execution output via regex (deprecated, kept for backward compatibility)
@@ -568,13 +640,16 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 						time.Since(iterStart),
 					)
 				}
+				trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, code, subquery, resultResponse, "", time.Since(iterStart), execErr == nil, execErr))
 
-				return &CompletionResult{
+				completion := &CompletionResult{
 					Response:   resultResponse,
 					Iterations: i + 1,
 					Duration:   time.Since(start),
 					Usage:      r.tokenTracker.GetTotalUsage(),
-				}, nil
+				}
+				finalizeRLMTrace(trace, completion, "regex_final", nil)
+				return completion, trace, nil
 			}
 
 			// Log iteration to trace
@@ -607,6 +682,7 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 				}
 			}
 			r.appendIterationHistory(&history, i+1, action, reasoning, code, execOutput)
+			trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, code, subquery, execOutput, "", time.Since(iterStart), execErr == nil, execErr))
 		} else if action != "final" {
 			// Log non-code iteration to trace
 			if traceSession != nil {
@@ -619,6 +695,7 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 				)
 			}
 			r.appendIterationHistory(&history, i+1, action, reasoning, "", "")
+			trace.Steps = append(trace.Steps, newRLMTraceStep(i+1, reasoning, action, "", subquery, "", "", time.Since(iterStart), true, nil))
 		}
 
 		// Detect confidence signals for adaptive early termination
@@ -635,7 +712,9 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 			if r.config.Verbose {
 				logger.Info(ctx, "[RLM] Early termination triggered (confidence signals: %d)", confidenceSignals)
 			}
-			return r.forceDefaultAnswer(ctx, replEnv, query, history.String(), start, maxIterations)
+			result, err := r.forceDefaultAnswer(ctx, replEnv, query, history.String(), start, maxIterations)
+			finalizeRLMTrace(trace, result, "early_termination", err)
+			return result, trace, err
 		}
 
 		// Apply history compression if enabled
@@ -653,7 +732,9 @@ func (r *RLM) Complete(ctx context.Context, contextPayload any, query string) (*
 	}
 
 	// Max iterations exhausted - force final answer
-	return r.forceDefaultAnswer(ctx, replEnv, query, history.String(), start, maxIterations)
+	result, err := r.forceDefaultAnswer(ctx, replEnv, query, history.String(), start, maxIterations)
+	finalizeRLMTrace(trace, result, "max_iterations", err)
+	return result, trace, err
 }
 
 // executeSubRLM spawns a nested RLM loop that shares REPL state with the parent.
@@ -702,7 +783,7 @@ func (r *RLM) executeSubRLM(ctx context.Context, replEnv *YaegiREPL, subquery, p
 
 	// Create sub-RLM instance
 	subRLM := &RLM{
-		BaseModule:      *core.NewModule(RLMSignature()),
+		BaseModule:      *core.NewModule(RLMSignatureWithInstruction(resolveOuterInstruction(subConfig))),
 		config:          subConfig,
 		rootLLM:         r.rootLLM,
 		subLLMClient:    r.subLLMClient,
@@ -1225,7 +1306,7 @@ func (r *RLM) Clone() core.Module {
 
 	return &RLM{
 		BaseModule:      *r.BaseModule.Clone().(*core.BaseModule),
-		config:          r.config,
+		config:          cloneConfig(r.config),
 		rootLLM:         r.rootLLM,
 		subLLMClient:    r.subLLMClient,
 		tokenTracker:    NewTokenTracker(),
@@ -1311,6 +1392,46 @@ func formatREPLStateRich(variables []REPLVariable, maxPreviewLen int) string {
 	}
 
 	return result.String()
+}
+
+func newRLMTraceStep(index int, thought, action, code, subquery, observation, errorText string, duration time.Duration, success bool, err error) RLMTraceStep {
+	step := RLMTraceStep{
+		Index:       index,
+		Thought:     thought,
+		Action:      action,
+		Code:        code,
+		SubQuery:    subquery,
+		Observation: observation,
+		Duration:    duration,
+		Success:     success,
+		Error:       errorText,
+	}
+	if err != nil && step.Error == "" {
+		step.Error = err.Error()
+	}
+	return step
+}
+
+func finalizeRLMTrace(trace *RLMTrace, result *CompletionResult, terminationCause string, err error) {
+	if trace == nil {
+		return
+	}
+
+	trace.CompletedAt = time.Now()
+	trace.ProcessingTime = trace.CompletedAt.Sub(trace.StartedAt)
+	trace.TerminationCause = terminationCause
+
+	if result != nil {
+		trace.Output = map[string]any{
+			"answer": result.Response,
+		}
+		trace.Iterations = result.Iterations
+		trace.Usage = result.Usage
+	}
+
+	if err != nil {
+		trace.Error = err.Error()
+	}
 }
 
 // trackTokenUsage extracts token usage from the execution state and records it.

--- a/pkg/modules/rlm/rlm_trace.go
+++ b/pkg/modules/rlm/rlm_trace.go
@@ -1,0 +1,59 @@
+package rlm
+
+import (
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+)
+
+// RLMTraceStep captures one iteration of the RLM loop.
+type RLMTraceStep struct {
+	Index       int
+	Thought     string
+	Action      string
+	Code        string
+	SubQuery    string
+	Observation string
+	Duration    time.Duration
+	Success     bool
+	Error       string
+}
+
+// RLMTrace captures a structured RLM completion, including iterative steps.
+type RLMTrace struct {
+	Input            map[string]any
+	Output           map[string]any
+	Steps            []RLMTraceStep
+	StartedAt        time.Time
+	CompletedAt      time.Time
+	ProcessingTime   time.Duration
+	Iterations       int
+	Usage            core.TokenUsage
+	TerminationCause string
+	Error            string
+}
+
+// Clone returns a deep copy of the trace.
+func (t *RLMTrace) Clone() *RLMTrace {
+	if t == nil {
+		return nil
+	}
+
+	cloned := &RLMTrace{
+		Input:            core.ShallowCopyMap(t.Input),
+		Output:           core.ShallowCopyMap(t.Output),
+		StartedAt:        t.StartedAt,
+		CompletedAt:      t.CompletedAt,
+		ProcessingTime:   t.ProcessingTime,
+		Iterations:       t.Iterations,
+		Usage:            t.Usage,
+		TerminationCause: t.TerminationCause,
+		Error:            t.Error,
+	}
+	if t.Steps != nil {
+		cloned.Steps = make([]RLMTraceStep, len(t.Steps))
+		copy(cloned.Steps, t.Steps)
+	}
+
+	return cloned
+}

--- a/pkg/modules/rlm/signatures.go
+++ b/pkg/modules/rlm/signatures.go
@@ -4,6 +4,8 @@ import (
 	"github.com/XiaoConstantine/dspy-go/pkg/core"
 )
 
+const defaultOuterInstruction = "Analyze the context using iterative code exploration to answer the query."
+
 const compactIterationInstruction = `You are exploring a large context using a Go REPL.
 
 Return these fields in order every time:
@@ -132,6 +134,15 @@ REMEMBER: You MUST start your response with "Reasoning:" and include all five fi
 // RLMSignature creates the main RLM module signature.
 // This is the outer interface: takes context + query, returns answer.
 func RLMSignature() core.Signature {
+	return RLMSignatureWithInstruction(defaultOuterInstruction)
+}
+
+// RLMSignatureWithInstruction creates the outer RLM signature with an explicit instruction override.
+func RLMSignatureWithInstruction(instruction string) core.Signature {
+	if instruction == "" {
+		instruction = defaultOuterInstruction
+	}
+
 	return core.NewSignature(
 		[]core.InputField{
 			{Field: core.NewField("context",
@@ -146,7 +157,7 @@ func RLMSignature() core.Signature {
 				core.WithDescription("The final answer to the query"),
 			)},
 		},
-	).WithInstruction("Analyze the context using iterative code exploration to answer the query.")
+	).WithInstruction(instruction)
 }
 
 // IterationSignature defines the signature for each RLM iteration.
@@ -159,6 +170,19 @@ func IterationSignature() core.Signature {
 // It keeps the same schema but substantially reduces repeated static prompt overhead.
 func CompactIterationSignature() core.Signature {
 	return iterationSignatureWithInstruction(compactIterationInstruction)
+}
+
+// DefaultOuterInstruction returns the built-in outer RLM instruction.
+func DefaultOuterInstruction() string {
+	return defaultOuterInstruction
+}
+
+// DefaultIterationInstruction returns the built-in iteration instruction for the given mode.
+func DefaultIterationInstruction(compact bool) string {
+	if compact {
+		return compactIterationInstruction
+	}
+	return fullIterationInstruction
 }
 
 func iterationSignatureWithInstruction(instruction string) core.Signature {

--- a/pkg/modules/rlm/trace_config_test.go
+++ b/pkg/modules/rlm/trace_config_test.go
@@ -1,0 +1,52 @@
+package rlm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRLMCompleteWithTrace_RecordsStructuredSteps(t *testing.T) {
+	llm := &mockLLM{
+		responses: []string{
+			"Reasoning:\nI'll provide the answer directly.\n\nAction:\nfinal\n\nCode:\n\nAnswer:\ntrace answer",
+		},
+	}
+
+	module := NewFromLLM(llm, WithMaxIterations(1))
+
+	result, trace, err := module.CompleteWithTrace(context.Background(), "ctx", "what is the answer?")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, trace)
+
+	assert.Equal(t, "trace answer", result.Response)
+	assert.Equal(t, "final_answer", trace.TerminationCause)
+	assert.Equal(t, 1, trace.Iterations)
+	assert.Equal(t, "trace answer", trace.Output["answer"])
+	require.Len(t, trace.Steps, 1)
+	assert.Equal(t, "final", trace.Steps[0].Action)
+	assert.Equal(t, "I'll provide the answer directly.", trace.Steps[0].Thought)
+}
+
+func TestRLMSetConfig_RebuildsPromptInstructions(t *testing.T) {
+	llm := &mockLLM{
+		responses: []string{
+			"Reasoning:\nDone.\n\nAction:\nfinal\n\nCode:\n\nAnswer:\ncomplete",
+		},
+	}
+
+	module := NewFromLLM(llm)
+	cfg := module.Config()
+	cfg.OuterInstruction = "Custom outer instruction."
+	cfg.IterationInstruction = "Custom iteration instruction."
+	cfg.UseIterationDemos = true
+	module.SetConfig(cfg)
+
+	assert.Equal(t, "Custom outer instruction.", module.GetSignature().Instruction)
+	require.NotNil(t, module.iterationModule)
+	assert.Equal(t, "Custom iteration instruction.", module.iterationModule.GetSignature().Instruction)
+	assert.True(t, module.Config().UseIterationDemos)
+}


### PR DESCRIPTION
## Summary
- add a GEPA-optimizable RLM-backed agent wrapper with artifact mutation and trace export
- make RLM instructions/config clone-safe and expose a canonical `CompleteWithTrace` path
- cover the new path with RLM trace/config tests, agent tests, and a minimal GEPA optimization test

## Testing
- `go test ./pkg/modules/rlm ./pkg/agents/rlm ./pkg/agents/optimize ./pkg/agents/skills`
- `go test ./pkg/agents/... ./pkg/modules/rlm`
- `golangci-lint run ./...`

## Issues
- closes #219