### PR TITLE
agents: fix file skill store save lock

### DIFF
--- a/pkg/agents/skills/store.go
+++ b/pkg/agents/skills/store.go
@@ -113,8 +113,8 @@ func (s *FileStore) Save(ctx context.Context, skill Skill) error {
 		return err
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	skills, err := s.readAllLocked()
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix FileStore.Save to use a write lock instead of a read lock
- keep FileStore.Load on a read lock
- preserve the current file-backed skill store behavior while preventing concurrent save races

## Testing
- go test ./pkg/agents/skills
- golangci-lint run ./...