### PR TITLE
llms: preserve Gemini thought signatures in tool loops

### DIFF
--- a/pkg/core/tool_call.go
+++ b/pkg/core/tool_call.go
@@ -3,7 +3,8 @@ package core
 // ToolCall represents a tool invocation requested by an LLM.
 // Used across packages: core.ChatMessage, agents.Message, tools.ParseToolCalls.
 type ToolCall struct {
-	ID        string         `json:"id"`        // provider-assigned ID; required for tool-result correlation
+	ID        string         `json:"id"` // provider-assigned ID; required for tool-result correlation
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
 }

--- a/pkg/interceptors/function_calling.go
+++ b/pkg/interceptors/function_calling.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/XiaoConstantine/dspy-go/pkg/core"
 	"github.com/XiaoConstantine/dspy-go/pkg/logging"
@@ -95,6 +96,15 @@ func NativeFunctionCallingInterceptor(config FunctionCallingConfig) core.ModuleI
 
 		logger.Debug(ctx, "Using native function calling with %d functions", len(functions))
 
+		if chatLLM, ok := llm.(core.ToolCallingChatLLM); ok {
+			result, err := generateWithToolHistory(ctx, chatLLM, inputs, info, functions)
+			if err != nil {
+				logger.Error(ctx, "GenerateWithTools failed: %v", err)
+				return nil, fmt.Errorf("native tool calling failed: %w", err)
+			}
+			return transformFunctionCallResult(result, inputs)
+		}
+
 		// Call LLM with function calling
 		result, err := llm.GenerateWithFunctions(ctx, prompt, functions)
 		if err != nil {
@@ -105,6 +115,103 @@ func NativeFunctionCallingInterceptor(config FunctionCallingConfig) core.ModuleI
 		// Transform the result into the expected ReAct format
 		return transformFunctionCallResult(result, inputs)
 	}
+}
+
+const (
+	nativeToolHistoryKey         = "_native_tool_history"
+	nativeToolPendingCallIDKey   = "_native_tool_pending_call_id"
+	nativeToolPendingToolNameKey = "_native_tool_pending_tool_name"
+	nativeToolLastObsKey         = "_native_tool_last_observation"
+)
+
+func generateWithToolHistory(ctx context.Context, llm core.ToolCallingChatLLM, inputs map[string]any, info *core.ModuleInfo, functions []map[string]any) (map[string]any, error) {
+	messages := nativeToolHistoryFromInputs(inputs)
+	if len(messages) == 0 {
+		messages = []core.ChatMessage{
+			{
+				Role:    "user",
+				Content: []core.ContentBlock{core.NewTextBlock(buildPromptFromInputs(inputs, info))},
+			},
+		}
+	}
+	messages, appendedObservation := appendPendingToolResult(messages, inputs)
+
+	result, err := llm.GenerateWithTools(ctx, messages, functions)
+	if err != nil {
+		return nil, err
+	}
+
+	history := append([]core.ChatMessage{}, messages...)
+	assistantMessage := core.ChatMessage{Role: "assistant"}
+	if blocks, ok := result["content_blocks"].([]core.ContentBlock); ok {
+		assistantMessage.Content = blocks
+	} else if content, ok := result["content"].(string); ok && content != "" {
+		assistantMessage.Content = []core.ContentBlock{core.NewTextBlock(content)}
+	}
+	if toolCalls, ok := result["tool_calls"].([]core.ToolCall); ok {
+		assistantMessage.ToolCalls = toolCalls
+	}
+	if len(assistantMessage.Content) > 0 || len(assistantMessage.ToolCalls) > 0 {
+		history = append(history, assistantMessage)
+	}
+
+	result[nativeToolHistoryKey] = history
+	if appendedObservation != "" {
+		result[nativeToolLastObsKey] = appendedObservation
+	}
+	if len(assistantMessage.ToolCalls) > 0 {
+		first := assistantMessage.ToolCalls[0]
+		if _, exists := result["function_call"]; !exists {
+			functionCall := map[string]any{
+				"name":      first.Name,
+				"arguments": first.Arguments,
+			}
+			if len(first.Metadata) > 0 {
+				functionCall["metadata"] = first.Metadata
+			}
+			result["function_call"] = functionCall
+		}
+		result[nativeToolPendingCallIDKey] = first.ID
+		result[nativeToolPendingToolNameKey] = first.Name
+		result[nativeToolLastObsKey] = ""
+	}
+	return result, nil
+}
+
+func nativeToolHistoryFromInputs(inputs map[string]any) []core.ChatMessage {
+	raw, ok := inputs[nativeToolHistoryKey]
+	if !ok || raw == nil {
+		return nil
+	}
+	history, ok := raw.([]core.ChatMessage)
+	if !ok {
+		return nil
+	}
+	return append([]core.ChatMessage{}, history...)
+}
+
+func appendPendingToolResult(history []core.ChatMessage, inputs map[string]any) ([]core.ChatMessage, string) {
+	observation, _ := inputs["observation"].(string)
+	if strings.TrimSpace(observation) == "" {
+		return history, ""
+	}
+
+	callID, _ := inputs[nativeToolPendingCallIDKey].(string)
+	toolName, _ := inputs[nativeToolPendingToolNameKey].(string)
+	lastObservation, _ := inputs[nativeToolLastObsKey].(string)
+	if callID == "" || toolName == "" || observation == lastObservation {
+		return history, ""
+	}
+
+	msg := core.ChatMessage{
+		Role: "tool",
+		ToolResult: &core.ChatToolResult{
+			ToolCallID: callID,
+			Name:       toolName,
+			Content:    []core.ContentBlock{core.NewTextBlock(observation)},
+		},
+	}
+	return append(history, msg), observation
 }
 
 // supportsToolCalling checks if the LLM supports native function/tool calling.
@@ -189,6 +296,11 @@ func transformFunctionCallResult(result map[string]interface{}, originalInputs m
 	// Copy through original inputs that should be preserved
 	for key, value := range originalInputs {
 		output[key] = value
+	}
+	for key, value := range result {
+		if strings.HasPrefix(key, "_native_") {
+			output[key] = value
+		}
 	}
 
 	// Extract function call from result

--- a/pkg/interceptors/function_calling_test.go
+++ b/pkg/interceptors/function_calling_test.go
@@ -47,8 +47,11 @@ type mockLLMWithFunctionCalling struct {
 	core.BaseLLM
 	generateWithFunctionsResult map[string]interface{}
 	generateWithFunctionsError  error
+	generateWithToolsResult     map[string]interface{}
+	generateWithToolsError      error
 	lastFunctions               []map[string]interface{}
 	lastPrompt                  string
+	lastMessages                []core.ChatMessage
 }
 
 func newMockLLMWithFunctionCalling() *mockLLMWithFunctionCalling {
@@ -75,6 +78,15 @@ func (m *mockLLMWithFunctionCalling) GenerateWithFunctions(ctx context.Context, 
 		return nil, m.generateWithFunctionsError
 	}
 	return m.generateWithFunctionsResult, nil
+}
+
+func (m *mockLLMWithFunctionCalling) GenerateWithTools(ctx context.Context, messages []core.ChatMessage, tools []map[string]any, options ...core.GenerateOption) (map[string]interface{}, error) {
+	m.lastMessages = append([]core.ChatMessage{}, messages...)
+	m.lastFunctions = tools
+	if m.generateWithToolsError != nil {
+		return nil, m.generateWithToolsError
+	}
+	return m.generateWithToolsResult, nil
 }
 
 func (m *mockLLMWithFunctionCalling) CreateEmbedding(ctx context.Context, input string, options ...core.EmbeddingOption) (*core.EmbeddingResult, error) {
@@ -407,11 +419,14 @@ func TestSupportsToolCalling(t *testing.T) {
 func TestNativeFunctionCallingInterceptor_WithToolCallingLLM(t *testing.T) {
 	// Setup mock LLM with function calling
 	mockLLM := newMockLLMWithFunctionCalling()
-	mockLLM.generateWithFunctionsResult = map[string]interface{}{
-		"function_call": map[string]interface{}{
-			"name": "search",
-			"arguments": map[string]interface{}{
-				"query": "test query",
+	mockLLM.generateWithToolsResult = map[string]interface{}{
+		"tool_calls": []core.ToolCall{
+			{
+				ID:   "call-1",
+				Name: "search",
+				Arguments: map[string]interface{}{
+					"query": "test query",
+				},
 			},
 		},
 	}
@@ -464,9 +479,67 @@ func TestNativeFunctionCallingInterceptor_WithToolCallingLLM(t *testing.T) {
 	action, ok := result["action"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "search", action["tool_name"])
+	assert.NotNil(t, result[nativeToolHistoryKey])
+	assert.Equal(t, "call-1", result[nativeToolPendingCallIDKey])
 
 	// Verify the functions were passed to the LLM
 	assert.Len(t, mockLLM.lastFunctions, 2) // search + Finish
+	assert.Len(t, mockLLM.lastMessages, 1)
+}
+
+func TestNativeFunctionCallingInterceptor_WithChatHistoryAppendsToolResult(t *testing.T) {
+	mockLLM := newMockLLMWithFunctionCalling()
+	mockLLM.generateWithToolsResult = map[string]interface{}{
+		"content": "done",
+		"tool_calls": []core.ToolCall{
+			{
+				ID:        "call-2",
+				Name:      "Finish",
+				Arguments: map[string]any{"answer": "done"},
+				Metadata: map[string]any{
+					"gemini_thought_signature": "sig-2",
+				},
+			},
+		},
+	}
+
+	originalLLM := core.GlobalConfig.DefaultLLM
+	core.GlobalConfig.DefaultLLM = mockLLM
+	defer func() { core.GlobalConfig.DefaultLLM = originalLLM }()
+
+	registry := tools.NewInMemoryToolRegistry()
+	err := registry.Register(&mockTool{
+		name:        "search",
+		description: "Search for information",
+		schema:      models.InputSchema{Type: "object", Properties: map[string]models.ParameterSchema{}},
+	})
+	require.NoError(t, err)
+
+	interceptor := NativeFunctionCallingInterceptor(FunctionCallingConfig{
+		ToolRegistry:      registry,
+		IncludeFinishTool: true,
+	})
+
+	history := []core.ChatMessage{
+		{Role: "user", Content: []core.ContentBlock{core.NewTextBlock("Task: Find info")}},
+		{Role: "assistant", ToolCalls: []core.ToolCall{{ID: "call-1", Name: "search", Arguments: map[string]any{"query": "x"}}}},
+	}
+	result, err := interceptor(context.Background(), map[string]any{
+		"task":                       "Find information",
+		"observation":                "search result",
+		nativeToolHistoryKey:         history,
+		nativeToolPendingCallIDKey:   "call-1",
+		nativeToolPendingToolNameKey: "search",
+		nativeToolLastObsKey:         "",
+	}, nil, func(ctx context.Context, inputs map[string]any, opts ...core.Option) (map[string]any, error) {
+		return map[string]any{"fallback": true}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, mockLLM.lastMessages, 3)
+	require.NotNil(t, mockLLM.lastMessages[2].ToolResult)
+	assert.Equal(t, "call-1", mockLLM.lastMessages[2].ToolResult.ToolCallID)
+	assert.Equal(t, "search", mockLLM.lastMessages[2].ToolResult.Name)
+	assert.Equal(t, "Finish", result["action"].(map[string]any)["tool_name"])
 }
 
 func TestNativeFunctionCallingInterceptor_FallbackWithoutToolCalling(t *testing.T) {

--- a/pkg/llms/gemini.go
+++ b/pkg/llms/gemini.go
@@ -30,13 +30,7 @@ type GeminiLLM struct {
 type geminiRequest struct {
 	Contents         []geminiContent        `json:"contents"`
 	GenerationConfig geminiGenerationConfig `json:"generationConfig,omitempty"`
-}
-
-// Add this to your existing geminiRequest struct or create a new one for function calling.
-type geminiRequestWithFunction struct {
-	Contents         []geminiContent        `json:"contents"`
 	Tools            []geminiTool           `json:"tools,omitempty"`
-	GenerationConfig geminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 
 // Add these new types to support function calling.
@@ -55,9 +49,18 @@ type geminiContent struct {
 }
 
 type geminiPart struct {
-	Text       string            `json:"text,omitempty"`
-	InlineData *geminiInlineData `json:"inline_data,omitempty"`
-	FileData   *geminiFileData   `json:"file_data,omitempty"`
+	Text             string                      `json:"text,omitempty"`
+	InlineData       *geminiInlineData           `json:"inline_data,omitempty"`
+	FileData         *geminiFileData             `json:"file_data,omitempty"`
+	FunctionCall     *geminiFunctionCall         `json:"function_call,omitempty"`
+	FunctionResponse *geminiFunctionResponsePart `json:"function_response,omitempty"`
+	Thought          bool                        `json:"thought,omitempty"`
+	ThoughtSignature string                      `json:"thoughtSignature,omitempty"`
+}
+
+type geminiFunctionResponsePart struct {
+	Name     string                 `json:"name"`
+	Response map[string]interface{} `json:"response"`
 }
 
 // geminiInlineData represents inline binary data (base64 encoded).
@@ -73,40 +76,42 @@ type geminiFileData struct {
 }
 
 type geminiGenerationConfig struct {
-	Temperature     float64 `json:"temperature,omitempty"`
-	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
-	TopP            float64 `json:"topP,omitempty"`
+	Temperature     float64               `json:"temperature,omitempty"`
+	MaxOutputTokens int                   `json:"maxOutputTokens,omitempty"`
+	TopP            float64               `json:"topP,omitempty"`
+	ThinkingConfig  *geminiThinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+type geminiThinkingConfig struct {
+	IncludeThoughts bool `json:"includeThoughts,omitempty"`
 }
 
 // GeminiResponse represents the response structure from Gemini API.
 type geminiResponse struct {
 	Candidates []struct {
 		Content struct {
-			Parts []struct {
-				Text string `json:"text"`
-			} `json:"parts"`
+			Parts []geminiPart `json:"parts"`
 		} `json:"content"`
 	} `json:"candidates"`
 	UsageMetadata struct {
 		PromptTokenCount     int `json:"promptTokenCount"`
 		CandidatesTokenCount int `json:"candidatesTokenCount"`
 		TotalTokenCount      int `json:"totalTokenCount"`
+		ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
 	} `json:"usageMetadata"`
 }
 
-type geminiFunctionResponse struct {
+type geminiFunctionCallResponse struct {
 	Candidates []struct {
 		Content struct {
-			Parts []struct {
-				Text         string              `json:"text,omitempty"`
-				FunctionCall *geminiFunctionCall `json:"function_call,omitempty"`
-			} `json:"parts"`
+			Parts []geminiPart `json:"parts"`
 		} `json:"content"`
 	} `json:"candidates"`
 	UsageMetadata struct {
 		PromptTokenCount     int `json:"promptTokenCount"`
 		CandidatesTokenCount int `json:"candidatesTokenCount"`
 		TotalTokenCount      int `json:"totalTokenCount"`
+		ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
 	} `json:"usageMetadata"`
 }
 type geminiFunctionCall struct {
@@ -329,6 +334,272 @@ func supportsGeminiFunctionCalling(_ core.ModelID) bool {
 	return true
 }
 
+const (
+	geminiThoughtMetadataKey          = "gemini_thought"
+	geminiThoughtSignatureMetadataKey = "gemini_thought_signature"
+)
+
+func supportsGeminiThoughtSignatures(modelID core.ModelID) bool {
+	model := strings.ToLower(strings.TrimSpace(string(modelID)))
+	return strings.HasPrefix(model, "gemini-3")
+}
+
+// Gemini 3 thought signatures must be round-tripped when tool calling is active.
+// We currently enable thoughts automatically for Gemini 3 family models so the
+// caller receives the signatures needed for subsequent function-response turns.
+func (g *GeminiLLM) buildGenerationConfig(opts *core.GenerateOptions) geminiGenerationConfig {
+	cfg := geminiGenerationConfig{
+		Temperature:     opts.Temperature,
+		MaxOutputTokens: opts.MaxTokens,
+		TopP:            opts.TopP,
+	}
+	if supportsGeminiThoughtSignatures(core.ModelID(g.ModelID())) {
+		cfg.ThinkingConfig = &geminiThinkingConfig{IncludeThoughts: true}
+	}
+	return cfg
+}
+
+func geminiUsageToTokenInfo(metadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+	ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
+}) *core.TokenInfo {
+	return &core.TokenInfo{
+		PromptTokens:     metadata.PromptTokenCount,
+		CompletionTokens: metadata.CandidatesTokenCount,
+		TotalTokens:      metadata.TotalTokenCount,
+	}
+}
+
+func geminiUsageMetadataMap(metadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+	ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
+}) map[string]any {
+	result := map[string]any{}
+	if metadata.ThoughtsTokenCount > 0 {
+		result["thoughts_token_count"] = metadata.ThoughtsTokenCount
+	}
+	return result
+}
+
+func buildGeminiContentResponse(parts []geminiPart) (string, []core.ContentBlock, []core.ToolCall, map[string]any) {
+	var (
+		textParts     []string
+		contentBlocks []core.ContentBlock
+		toolCalls     []core.ToolCall
+		thoughtBlocks []core.ContentBlock
+	)
+
+	for idx, part := range parts {
+		if part.Text != "" {
+			block := core.NewTextBlock(part.Text)
+			if part.Thought {
+				if block.Metadata == nil {
+					block.Metadata = map[string]any{}
+				}
+				block.Metadata[geminiThoughtMetadataKey] = true
+				if part.ThoughtSignature != "" {
+					block.Metadata[geminiThoughtSignatureMetadataKey] = part.ThoughtSignature
+				}
+				thoughtBlocks = append(thoughtBlocks, block)
+			} else {
+				textParts = append(textParts, part.Text)
+				contentBlocks = append(contentBlocks, block)
+			}
+		}
+
+		if part.FunctionCall != nil {
+			call := core.ToolCall{
+				ID:        fmt.Sprintf("gemini-call-%d", idx),
+				Name:      part.FunctionCall.Name,
+				Arguments: part.FunctionCall.Arguments,
+			}
+			if part.Thought || part.ThoughtSignature != "" {
+				call.Metadata = map[string]any{}
+				if part.Thought {
+					call.Metadata[geminiThoughtMetadataKey] = true
+				}
+				if part.ThoughtSignature != "" {
+					call.Metadata[geminiThoughtSignatureMetadataKey] = part.ThoughtSignature
+				}
+			}
+			toolCalls = append(toolCalls, call)
+		}
+	}
+
+	metadata := map[string]any{}
+	if len(thoughtBlocks) > 0 {
+		metadata["thought_blocks"] = thoughtBlocks
+	}
+	if len(toolCalls) > 0 {
+		metadata["tool_call_count"] = len(toolCalls)
+	}
+
+	return strings.Join(textParts, " "), contentBlocks, toolCalls, metadata
+}
+
+func (g *GeminiLLM) chatMessagesToGeminiContents(messages []core.ChatMessage) []geminiContent {
+	contents := make([]geminiContent, 0, len(messages))
+	for _, msg := range messages {
+		// Gemini expects tool results as function_response parts rather than a
+		// standalone "tool" role. If we somehow receive a tool-role message
+		// without a tool result payload, drop it instead of emitting a malformed
+		// synthetic user turn.
+		if msg.Role == "tool" && msg.ToolResult == nil {
+			continue
+		}
+
+		content := geminiContent{
+			Role:  geminiRoleForChatMessage(msg.Role),
+			Parts: make([]geminiPart, 0, len(msg.Content)+len(msg.ToolCalls)+1),
+		}
+
+		if msg.ToolResult != nil {
+			response := map[string]any{
+				"content": contentBlocksToText(msg.ToolResult.Content),
+			}
+			content.Parts = append(content.Parts, geminiPart{
+				FunctionResponse: &geminiFunctionResponsePart{
+					Name:     msg.ToolResult.Name,
+					Response: response,
+				},
+			})
+		} else {
+			content.Parts = append(content.Parts, g.convertToGeminiParts(msg.Content)...)
+		}
+
+		for _, toolCall := range msg.ToolCalls {
+			part := geminiPart{
+				FunctionCall: &geminiFunctionCall{
+					Name:      toolCall.Name,
+					Arguments: toolCall.Arguments,
+				},
+			}
+			if toolCall.Metadata != nil {
+				if thought, ok := toolCall.Metadata[geminiThoughtMetadataKey].(bool); ok {
+					part.Thought = thought
+				}
+				if signature, ok := toolCall.Metadata[geminiThoughtSignatureMetadataKey].(string); ok {
+					part.ThoughtSignature = signature
+				}
+			}
+			content.Parts = append(content.Parts, part)
+		}
+
+		if len(content.Parts) == 0 {
+			continue
+		}
+		contents = append(contents, content)
+	}
+	return contents
+}
+
+func geminiRoleForChatMessage(role string) string {
+	switch role {
+	case "assistant":
+		return "model"
+	default:
+		return "user"
+	}
+}
+
+func (g *GeminiLLM) doGeminiRequest(ctx context.Context, reqBody any, dest any) error {
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return errors.WithFields(
+			errors.New(errors.InvalidInput, fmt.Sprintf("failed to marshal Gemini request body: %v", err)),
+			errors.Fields{"model": g.ModelID()},
+		)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		"POST",
+		constructRequestURL(g.GetEndpointConfig(), g.apiKey),
+		bytes.NewBuffer(jsonData),
+	)
+	if err != nil {
+		return errors.WithFields(
+			errors.New(errors.InvalidInput, fmt.Sprintf("failed to create Gemini request: %v", err)),
+			errors.Fields{"model": g.ModelID()},
+		)
+	}
+	for key, value := range g.GetEndpointConfig().Headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := g.GetHTTPClient().Do(req)
+	if err != nil {
+		return errors.WithFields(
+			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("LLMGenerationFailed: failed to send Gemini request: %v", err)),
+			errors.Fields{"model": g.ModelID()},
+		)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.WithFields(
+			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("LLMGenerationFailed: failed to read Gemini response body: %v", err)),
+			errors.Fields{"model": g.ModelID()},
+		)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.WithFields(
+			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("LLMGenerationFailed: API request failed with status code %d: %s", resp.StatusCode, string(body))),
+			errors.Fields{"model": g.ModelID(), "statusCode": resp.StatusCode},
+		)
+	}
+	if err := json.Unmarshal(body, dest); err != nil {
+		return errors.WithFields(
+			errors.New(errors.InvalidResponse, fmt.Sprintf("InvalidResponse: failed to unmarshal Gemini response: %v", err)),
+			errors.Fields{"model": g.ModelID(), "body": string(body)},
+		)
+	}
+	return nil
+}
+
+func contentBlocksToText(blocks []core.ContentBlock) string {
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == core.FieldTypeText && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func toolSchemasToDeclarations(tools []map[string]interface{}) ([]geminiFunctionDeclaration, error) {
+	functionDeclarations := make([]geminiFunctionDeclaration, 0, len(tools))
+	for _, tool := range tools {
+		name, ok := tool["name"].(string)
+		if !ok {
+			return nil, errors.WithFields(
+				errors.New(errors.InvalidInput, "tool schema missing 'name' field"),
+				errors.Fields{"tool": tool},
+			)
+		}
+		description, _ := tool["description"].(string)
+		parameters, ok := tool["parameters"].(map[string]interface{})
+		if !ok {
+			return nil, errors.WithFields(
+				errors.New(errors.InvalidInput, "tool schema missing 'parameters' field"),
+				errors.Fields{"tool": tool},
+			)
+		}
+
+		functionDeclarations = append(functionDeclarations, geminiFunctionDeclaration{
+			Name:        name,
+			Description: description,
+			Parameters:  parameters,
+		})
+	}
+	return functionDeclarations, nil
+}
+
 // Generate implements the core.LLM interface.
 func (g *GeminiLLM) Generate(ctx context.Context, prompt string, options ...core.GenerateOption) (*core.LLMResponse, error) {
 	opts := core.NewGenerateOptions()
@@ -344,76 +615,15 @@ func (g *GeminiLLM) Generate(ctx context.Context, prompt string, options ...core
 				},
 			},
 		},
-		GenerationConfig: geminiGenerationConfig{
-			Temperature:     opts.Temperature,
-			MaxOutputTokens: opts.MaxTokens,
-			TopP:            opts.TopP,
-		},
+		GenerationConfig: g.buildGenerationConfig(opts),
 	}
-
-	jsonData, err := json.Marshal(reqBody)
-	if err != nil {
+	var geminiResp geminiResponse
+	if err := g.doGeminiRequest(ctx, reqBody, &geminiResp); err != nil {
 		return nil, errors.WithFields(
-			errors.Wrap(err, errors.InvalidInput, "failed to marshal request body"),
+			err,
 			errors.Fields{
 				"prompt": prompt,
 				"model":  g.ModelID(),
-			})
-	}
-
-	req, err := http.NewRequestWithContext(
-		ctx,
-		"POST",
-		constructRequestURL(g.GetEndpointConfig(), g.apiKey),
-		bytes.NewBuffer(jsonData),
-	)
-
-	if err != nil {
-		return nil, errors.WithFields(
-			errors.Wrap(err, errors.InvalidInput, "failed to create request"),
-			errors.Fields{
-				"model": g.ModelID(),
-			})
-	}
-	// TODO: make basellm make request to dry this up
-	for key, value := range g.GetEndpointConfig().Headers {
-		req.Header.Set(key, value)
-	}
-
-	resp, err := g.GetHTTPClient().Do(req)
-	if err != nil {
-		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("LLMGenerationFailed: failed to send request: %v", err)),
-			errors.Fields{
-				"model": g.ModelID(),
-			})
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("LLMGenerationFailed: failed to read response body: %v", err)),
-			errors.Fields{
-				"model": g.ModelID(),
-			})
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("LLMGenerationFailed: API request failed with status code %d: %s", resp.StatusCode, string(body))),
-			errors.Fields{
-				"model":      g.ModelID(),
-				"statusCode": resp.StatusCode,
-			})
-	}
-
-	var geminiResp geminiResponse
-	if err := json.Unmarshal(body, &geminiResp); err != nil {
-		return nil, errors.WithFields(
-			errors.New(errors.InvalidResponse, fmt.Sprintf("InvalidResponse: failed to unmarshal response: %v", err)),
-			errors.Fields{
-				"model": g.ModelID(),
 			})
 	}
 
@@ -433,16 +643,17 @@ func (g *GeminiLLM) Generate(ctx context.Context, prompt string, options ...core
 			})
 	}
 
-	content := geminiResp.Candidates[0].Content.Parts[0].Text
-	usage := &core.TokenInfo{
-		PromptTokens:     geminiResp.UsageMetadata.PromptTokenCount,
-		CompletionTokens: geminiResp.UsageMetadata.CandidatesTokenCount,
-		TotalTokens:      geminiResp.UsageMetadata.TotalTokenCount,
+	content, _, _, responseMetadata := buildGeminiContentResponse(geminiResp.Candidates[0].Content.Parts)
+	usage := geminiUsageToTokenInfo(geminiResp.UsageMetadata)
+	metadata := geminiUsageMetadataMap(geminiResp.UsageMetadata)
+	for key, value := range responseMetadata {
+		metadata[key] = value
 	}
 
 	return &core.LLMResponse{
-		Content: content,
-		Usage:   usage,
+		Content:  content,
+		Usage:    usage,
+		Metadata: metadata,
 	}, nil
 }
 
@@ -464,41 +675,13 @@ func (g *GeminiLLM) GenerateWithFunctions(ctx context.Context, prompt string, fu
 		opt(opts)
 	}
 
-	// Convert the generic function schemas to Gemini's format
-	functionDeclarations := make([]geminiFunctionDeclaration, 0, len(functions))
-	for _, function := range functions {
-		name, ok := function["name"].(string)
-		if !ok {
-			return nil, errors.WithFields(
-				errors.New(errors.InvalidInput, "function schema missing 'name' field"),
-				errors.Fields{
-					"function": function,
-				})
-		}
-
-		description := ""
-		if desc, ok := function["description"].(string); ok {
-			description = desc
-		}
-
-		parameters, ok := function["parameters"].(map[string]interface{})
-		if !ok {
-			return nil, errors.WithFields(
-				errors.New(errors.InvalidInput, "function schema missing 'parameters' field"),
-				errors.Fields{
-					"function": function,
-				})
-		}
-
-		functionDeclarations = append(functionDeclarations, geminiFunctionDeclaration{
-			Name:        name,
-			Description: description,
-			Parameters:  parameters,
-		})
+	functionDeclarations, err := toolSchemasToDeclarations(functions)
+	if err != nil {
+		return nil, err
 	}
 
 	// Create the request body with functions
-	reqBody := geminiRequestWithFunction{
+	reqBody := geminiRequest{
 		Contents: []geminiContent{
 			{
 				Parts: []geminiPart{
@@ -512,86 +695,19 @@ func (g *GeminiLLM) GenerateWithFunctions(ctx context.Context, prompt string, fu
 				FunctionDeclarations: functionDeclarations,
 			},
 		},
-		GenerationConfig: geminiGenerationConfig{
-			Temperature:     opts.Temperature,
-			MaxOutputTokens: opts.MaxTokens,
-			TopP:            opts.TopP,
-		},
+		GenerationConfig: g.buildGenerationConfig(opts),
 	}
 	requestJSON, _ := json.MarshalIndent(reqBody, "", "  ")
 	logger.Debug(ctx, "Function call request JSON: %s", string(requestJSON))
 
-	jsonData, err := json.Marshal(reqBody)
-	if err != nil {
+	// Parse the response
+	var geminiResp geminiFunctionCallResponse
+	if err := g.doGeminiRequest(ctx, reqBody, &geminiResp); err != nil {
 		return nil, errors.WithFields(
-			errors.Wrap(err, errors.InvalidInput, "failed to marshal request body"),
+			err,
 			errors.Fields{
 				"prompt": prompt,
 				"model":  g.ModelID(),
-			})
-	}
-
-	// Create the request URL
-	req, err := http.NewRequestWithContext(
-		ctx,
-		"POST",
-		constructRequestURL(g.GetEndpointConfig(), g.apiKey),
-		bytes.NewBuffer(jsonData),
-	)
-
-	if err != nil {
-		return nil, errors.WithFields(
-			errors.Wrap(err, errors.InvalidInput, "failed to create request"),
-			errors.Fields{
-				"model": g.ModelID(),
-			})
-	}
-
-	// Set headers
-	for key, value := range g.GetEndpointConfig().Headers {
-		req.Header.Set(key, value)
-	}
-
-	// Send the request
-	resp, err := g.GetHTTPClient().Do(req)
-	if err != nil {
-		return nil, errors.WithFields(
-			errors.Wrap(err, errors.LLMGenerationFailed, "failed to send request"),
-			errors.Fields{
-				"model": g.ModelID(),
-			})
-	}
-	defer resp.Body.Close()
-
-	// Read and process the response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.WithFields(
-			errors.Wrap(err, errors.LLMGenerationFailed, "failed to read response body"),
-			errors.Fields{
-				"model": g.ModelID(),
-			})
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, fmt.Sprintf("API request failed with status code %d: %s", resp.StatusCode, string(body))),
-			errors.Fields{
-				"model":      g.ModelID(),
-				"statusCode": resp.StatusCode,
-			})
-	}
-
-	logger.Debug(ctx, "Raw Gemini response: %s", string(body))
-
-	// Parse the response
-	var geminiResp geminiFunctionResponse
-	if err := json.Unmarshal(body, &geminiResp); err != nil {
-		return nil, errors.WithFields(
-			errors.Wrap(err, errors.InvalidResponse, "failed to unmarshal response"),
-			errors.Fields{
-				"model": g.ModelID(),
-				"body":  string(body),
 			})
 	}
 
@@ -604,47 +720,38 @@ func (g *GeminiLLM) GenerateWithFunctions(ctx context.Context, prompt string, fu
 	}
 
 	// Extract usage information
-	usage := &core.TokenInfo{
-		PromptTokens:     geminiResp.UsageMetadata.PromptTokenCount,
-		CompletionTokens: geminiResp.UsageMetadata.CandidatesTokenCount,
-		TotalTokens:      geminiResp.UsageMetadata.TotalTokenCount,
-	}
+	usage := geminiUsageToTokenInfo(geminiResp.UsageMetadata)
 
 	// Process the response to extract function call if present
 	result := make(map[string]interface{})
 
 	// Check if there are any parts in the response
 	if len(geminiResp.Candidates[0].Content.Parts) > 0 {
-		// Process all parts
-		var textContent string
-		var functionCall *geminiFunctionCall
-
-		for _, part := range geminiResp.Candidates[0].Content.Parts {
-			// Collect text content
-			if part.Text != "" {
-				if textContent != "" {
-					textContent += " "
-				}
-				textContent += part.Text
-			}
-
-			// Get function call if present
-			if part.FunctionCall != nil {
-				functionCall = part.FunctionCall
-			}
-		}
+		textContent, contentBlocks, toolCalls, responseMetadata := buildGeminiContentResponse(geminiResp.Candidates[0].Content.Parts)
 
 		// Add text content if available
 		if textContent != "" {
 			result["content"] = textContent
 		}
 
-		// Add function call if available
-		if functionCall != nil {
+		if len(contentBlocks) > 0 {
+			result["content_blocks"] = contentBlocks
+		}
+
+		if len(toolCalls) > 0 {
+			result["tool_calls"] = toolCalls
+			call := toolCalls[0]
 			result["function_call"] = map[string]interface{}{
-				"name":      functionCall.Name,
-				"arguments": functionCall.Arguments,
+				"name":      call.Name,
+				"arguments": call.Arguments,
 			}
+			if len(call.Metadata) > 0 {
+				result["function_call"].(map[string]interface{})["metadata"] = call.Metadata
+			}
+		}
+
+		for key, value := range responseMetadata {
+			result[key] = value
 		}
 	}
 
@@ -655,6 +762,76 @@ func (g *GeminiLLM) GenerateWithFunctions(ctx context.Context, prompt string, fu
 
 	// Add token usage information
 	result["_usage"] = usage
+
+	return result, nil
+}
+
+// GenerateWithTools implements native multi-turn tool calling for Gemini.
+func (g *GeminiLLM) GenerateWithTools(ctx context.Context, messages []core.ChatMessage, tools []map[string]any, options ...core.GenerateOption) (map[string]interface{}, error) {
+	logger := logging.GetLogger()
+	opts := core.NewGenerateOptions()
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	functionDeclarations, err := toolSchemasToDeclarations(tools)
+	if err != nil {
+		return nil, err
+	}
+
+	reqBody := geminiRequest{
+		Contents:         g.chatMessagesToGeminiContents(messages),
+		GenerationConfig: g.buildGenerationConfig(opts),
+	}
+	if len(functionDeclarations) > 0 {
+		reqBody.Tools = []geminiTool{{FunctionDeclarations: functionDeclarations}}
+	}
+
+	requestJSON, _ := json.MarshalIndent(reqBody, "", "  ")
+	logger.Debug(ctx, "Gemini tool request JSON: %s", string(requestJSON))
+
+	var geminiResp geminiFunctionCallResponse
+	if err := g.doGeminiRequest(ctx, reqBody, &geminiResp); err != nil {
+		return nil, errors.WithFields(
+			err,
+			errors.Fields{"model": g.ModelID()},
+		)
+	}
+	if len(geminiResp.Candidates) == 0 {
+		return nil, errors.WithFields(
+			errors.New(errors.InvalidResponse, "no candidates in Gemini tool response"),
+			errors.Fields{"model": g.ModelID()},
+		)
+	}
+
+	textContent, contentBlocks, toolCalls, responseMetadata := buildGeminiContentResponse(geminiResp.Candidates[0].Content.Parts)
+	result := map[string]any{
+		"_usage": geminiUsageToTokenInfo(geminiResp.UsageMetadata),
+	}
+	if textContent != "" {
+		result["content"] = textContent
+	}
+	if len(contentBlocks) > 0 {
+		result["content_blocks"] = contentBlocks
+	}
+	if len(toolCalls) > 0 {
+		result["tool_calls"] = toolCalls
+		first := toolCalls[0]
+		functionCall := map[string]any{
+			"name":      first.Name,
+			"arguments": first.Arguments,
+		}
+		if len(first.Metadata) > 0 {
+			functionCall["metadata"] = first.Metadata
+		}
+		result["function_call"] = functionCall
+	}
+	for key, value := range geminiUsageMetadataMap(geminiResp.UsageMetadata) {
+		result[key] = value
+	}
+	for key, value := range responseMetadata {
+		result[key] = value
+	}
 
 	return result, nil
 }
@@ -1186,11 +1363,7 @@ func (g *GeminiLLM) GenerateWithContent(ctx context.Context, content []core.Cont
 				Parts: geminiParts,
 			},
 		},
-		GenerationConfig: geminiGenerationConfig{
-			Temperature:     opts.Temperature,
-			MaxOutputTokens: opts.MaxTokens,
-			TopP:            opts.TopP,
-		},
+		GenerationConfig: g.buildGenerationConfig(opts),
 	}
 
 	jsonData, err := json.Marshal(reqBody)
@@ -1275,16 +1448,17 @@ func (g *GeminiLLM) GenerateWithContent(ctx context.Context, content []core.Cont
 			})
 	}
 
-	content_text := geminiResp.Candidates[0].Content.Parts[0].Text
-	usage := &core.TokenInfo{
-		PromptTokens:     geminiResp.UsageMetadata.PromptTokenCount,
-		CompletionTokens: geminiResp.UsageMetadata.CandidatesTokenCount,
-		TotalTokens:      geminiResp.UsageMetadata.TotalTokenCount,
+	contentText, _, _, responseMetadata := buildGeminiContentResponse(geminiResp.Candidates[0].Content.Parts)
+	usage := geminiUsageToTokenInfo(geminiResp.UsageMetadata)
+	metadata := geminiUsageMetadataMap(geminiResp.UsageMetadata)
+	for key, value := range responseMetadata {
+		metadata[key] = value
 	}
 
 	return &core.LLMResponse{
-		Content: content_text,
-		Usage:   usage,
+		Content:  contentText,
+		Usage:    usage,
+		Metadata: metadata,
 	}, nil
 }
 
@@ -1304,11 +1478,7 @@ func (g *GeminiLLM) StreamGenerateWithContent(ctx context.Context, content []cor
 				Parts: geminiParts,
 			},
 		},
-		GenerationConfig: geminiGenerationConfig{
-			Temperature:     opts.Temperature,
-			MaxOutputTokens: opts.MaxTokens,
-			TopP:            opts.TopP,
-		},
+		GenerationConfig: g.buildGenerationConfig(opts),
 	}
 
 	return g.streamRequest(ctx, reqBody)
@@ -1321,9 +1491,18 @@ func (g *GeminiLLM) convertToGeminiParts(blocks []core.ContentBlock) []geminiPar
 	for _, block := range blocks {
 		switch block.Type {
 		case core.FieldTypeText:
-			parts = append(parts, geminiPart{
+			part := geminiPart{
 				Text: block.Text,
-			})
+			}
+			if block.Metadata != nil {
+				if thought, ok := block.Metadata[geminiThoughtMetadataKey].(bool); ok {
+					part.Thought = thought
+				}
+				if signature, ok := block.Metadata[geminiThoughtSignatureMetadataKey].(string); ok {
+					part.ThoughtSignature = signature
+				}
+			}
+			parts = append(parts, part)
 		case core.FieldTypeImage:
 			parts = append(parts, geminiPart{
 				InlineData: &geminiInlineData{

--- a/pkg/llms/gemini_test.go
+++ b/pkg/llms/gemini_test.go
@@ -20,6 +20,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testGeminiTextResponse(text string) geminiResponse {
+	var resp geminiResponse
+	resp.Candidates = []struct {
+		Content struct {
+			Parts []geminiPart `json:"parts"`
+		} `json:"content"`
+	}{
+		{
+			Content: struct {
+				Parts []geminiPart `json:"parts"`
+			}{
+				Parts: []geminiPart{{Text: text}},
+			},
+		},
+	}
+	return resp
+}
+
 func TestNewGeminiLLM(t *testing.T) {
 	originalEnv := os.Getenv("GEMINI_API_KEY")
 	defer os.Setenv("GEMINI_API_KEY", originalEnv)
@@ -118,38 +136,20 @@ func TestGeminiLLM_Generate(t *testing.T) {
 	}{
 		{
 			name: "Successful generation",
-			serverResponse: geminiResponse{
-				Candidates: []struct {
-					Content struct {
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"content"`
-				}{
-					{
-						Content: struct {
-							Parts []struct {
-								Text string `json:"text"`
-							} `json:"parts"`
-						}{
-							Parts: []struct {
-								Text string `json:"text"`
-							}{
-								{Text: "Generated text"},
-							},
-						},
-					},
-				},
-				UsageMetadata: struct {
+			serverResponse: func() geminiResponse {
+				resp := testGeminiTextResponse("Generated text")
+				resp.UsageMetadata = struct {
 					PromptTokenCount     int `json:"promptTokenCount"`
 					CandidatesTokenCount int `json:"candidatesTokenCount"`
 					TotalTokenCount      int `json:"totalTokenCount"`
+					ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
 				}{
 					PromptTokenCount:     10,
 					CandidatesTokenCount: 5,
 					TotalTokenCount:      15,
-				},
-			},
+				}
+				return resp
+			}(),
 			serverStatus: http.StatusOK,
 			expectError:  false,
 			expectedTokens: &core.TokenInfo{
@@ -166,16 +166,8 @@ func TestGeminiLLM_Generate(t *testing.T) {
 			expectedTokens: nil,
 		},
 		{
-			name: "Empty candidates",
-			serverResponse: geminiResponse{
-				Candidates: []struct {
-					Content struct {
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"content"`
-				}{},
-			},
+			name:           "Empty candidates",
+			serverResponse: geminiResponse{},
 			serverStatus:   http.StatusOK,
 			expectError:    true,
 			expectedTokens: nil,
@@ -250,60 +242,16 @@ func TestGeminiLLM_GenerateWithJSON(t *testing.T) {
 		expectedJSON   map[string]interface{}
 	}{
 		{
-			name: "Valid JSON response",
-			serverResponse: geminiResponse{
-				Candidates: []struct {
-					Content struct {
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"content"`
-				}{
-					{
-						Content: struct {
-							Parts []struct {
-								Text string `json:"text"`
-							} `json:"parts"`
-						}{
-							Parts: []struct {
-								Text string `json:"text"`
-							}{
-								{Text: `{"key": "value"}`},
-							},
-						},
-					},
-				},
-			},
-			expectError:  false,
-			expectedJSON: map[string]interface{}{"key": "value"},
+			name:           "Valid JSON response",
+			serverResponse: testGeminiTextResponse(`{"key": "value"}`),
+			expectError:    false,
+			expectedJSON:   map[string]interface{}{"key": "value"},
 		},
 		{
-			name: "Invalid JSON response",
-			serverResponse: geminiResponse{
-				Candidates: []struct {
-					Content struct {
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"content"`
-				}{
-					{
-						Content: struct {
-							Parts []struct {
-								Text string `json:"text"`
-							} `json:"parts"`
-						}{
-							Parts: []struct {
-								Text string `json:"text"`
-							}{
-								{Text: "invalid json"},
-							},
-						},
-					},
-				},
-			},
-			expectError:  true,
-			expectedJSON: nil,
+			name:           "Invalid JSON response",
+			serverResponse: testGeminiTextResponse("invalid json"),
+			expectError:    true,
+			expectedJSON:   nil,
 		},
 	}
 	for _, tt := range tests {
@@ -793,6 +741,104 @@ func TestGeminiLLM_GenerateWithFunctions(t *testing.T) {
 	assert.Equal(t, 15, usage.PromptTokens)
 	assert.Equal(t, 10, usage.CompletionTokens)
 	assert.Equal(t, 25, usage.TotalTokens)
+}
+
+func TestGeminiLLM_GenerateWithTools_PreservesThoughtSignature(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody geminiRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody.GenerationConfig.ThinkingConfig)
+		assert.True(t, reqBody.GenerationConfig.ThinkingConfig.IncludeThoughts)
+		require.Len(t, reqBody.Contents, 2)
+		require.Len(t, reqBody.Contents[1].Parts, 1)
+		require.NotNil(t, reqBody.Contents[1].Parts[0].FunctionResponse)
+		assert.Equal(t, "search", reqBody.Contents[1].Parts[0].FunctionResponse.Name)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"candidates": [{
+				"content": {
+					"parts": [
+						{
+							"text": "Need to use search",
+							"thought": true,
+							"thoughtSignature": "sig-thought"
+						},
+						{
+							"function_call": {
+								"name": "search",
+								"arguments": {"query": "gemini"}
+							},
+							"thought": true,
+							"thoughtSignature": "sig-call"
+						}
+					]
+				}
+			}],
+			"usageMetadata": {
+				"promptTokenCount": 12,
+				"candidatesTokenCount": 7,
+				"totalTokenCount": 19,
+				"thoughtsTokenCount": 3
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	llm := &GeminiLLM{
+		apiKey: "test-api-key",
+		BaseLLM: core.NewBaseLLM(
+			"google",
+			core.ModelGoogleGemini3FlashPreview,
+			[]core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling},
+			&core.EndpointConfig{
+				BaseURL:    server.URL,
+				Path:       "/models/gemini-3-flash-preview:generateContent",
+				Headers:    map[string]string{"Content-Type": "application/json"},
+				TimeoutSec: 30,
+			},
+		),
+	}
+
+	messages := []core.ChatMessage{
+		{Role: "user", Content: []core.ContentBlock{core.NewTextBlock("Find info")}},
+		{
+			Role: "tool",
+			ToolResult: &core.ChatToolResult{
+				ToolCallID: "call-1",
+				Name:       "search",
+				Content:    []core.ContentBlock{core.NewTextBlock("tool output")},
+			},
+		},
+	}
+	tools := []map[string]any{
+		{
+			"name":        "search",
+			"description": "Search docs",
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"query": map[string]any{"type": "string"}},
+			},
+		},
+	}
+
+	result, err := llm.GenerateWithTools(context.Background(), messages, tools)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	toolCalls, ok := result["tool_calls"].([]core.ToolCall)
+	require.True(t, ok)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "search", toolCalls[0].Name)
+	assert.Equal(t, "sig-call", toolCalls[0].Metadata["gemini_thought_signature"])
+	assert.Equal(t, true, toolCalls[0].Metadata["gemini_thought"])
+
+	thoughtBlocks, ok := result["thought_blocks"].([]core.ContentBlock)
+	require.True(t, ok)
+	require.Len(t, thoughtBlocks, 1)
+	assert.Equal(t, "sig-thought", thoughtBlocks[0].Metadata["gemini_thought_signature"])
+	assert.Equal(t, 3, result["thoughts_token_count"])
 }
 
 func TestGeminiLLM_StreamGenerate_ChunkHandling(t *testing.T) {
@@ -1339,7 +1385,7 @@ func TestGeminiLLM_GenerateWithFunctions_OptionsHandling(t *testing.T) {
 	// Create test server that verifies options are properly passed
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Decode the request to verify options are properly set
-		var reqBody geminiRequestWithFunction
+		var reqBody geminiRequest
 		err := json.NewDecoder(r.Body).Decode(&reqBody)
 		require.NoError(t, err)
 
@@ -1415,6 +1461,59 @@ func TestGeminiLLM_GenerateWithFunctions_OptionsHandling(t *testing.T) {
 	funcCall, ok := result["function_call"].(map[string]interface{})
 	assert.True(t, ok)
 	assert.Equal(t, "test_function", funcCall["name"])
+}
+
+func TestGeminiLLM_Generate_Gemini3IncludesThinkingConfig(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody geminiRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.NoError(t, err)
+		require.NotNil(t, reqBody.GenerationConfig.ThinkingConfig)
+		assert.True(t, reqBody.GenerationConfig.ThinkingConfig.IncludeThoughts)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"candidates": [{
+				"content": {
+					"parts": [
+						{"text": "reasoning", "thought": true, "thoughtSignature": "sig-1"},
+						{"text": "final answer"}
+					]
+				}
+			}],
+			"usageMetadata": {
+				"promptTokenCount": 10,
+				"candidatesTokenCount": 5,
+				"totalTokenCount": 15,
+				"thoughtsTokenCount": 2
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	llm := &GeminiLLM{
+		apiKey: "test-api-key",
+		BaseLLM: core.NewBaseLLM(
+			"google",
+			core.ModelGoogleGemini3FlashPreview,
+			[]core.Capability{core.CapabilityCompletion},
+			&core.EndpointConfig{
+				BaseURL:    server.URL,
+				Path:       "/models/gemini-3-flash-preview:generateContent",
+				Headers:    map[string]string{"Content-Type": "application/json"},
+				TimeoutSec: 30,
+			},
+		),
+	}
+
+	resp, err := llm.Generate(context.Background(), "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "final answer", resp.Content)
+	require.NotNil(t, resp.Metadata)
+	assert.Equal(t, 2, resp.Metadata["thoughts_token_count"])
+	thoughtBlocks, ok := resp.Metadata["thought_blocks"].([]core.ContentBlock)
+	require.True(t, ok)
+	require.Len(t, thoughtBlocks, 1)
+	assert.Equal(t, "sig-1", thoughtBlocks[0].Metadata["gemini_thought_signature"])
 }
 
 func TestGeminiLLM_CreateEmbedding_Options(t *testing.T) {

--- a/pkg/modules/react.go
+++ b/pkg/modules/react.go
@@ -187,6 +187,7 @@ func (r *ReAct) ProcessWithTrace(ctx context.Context, inputs map[string]any, opt
 		}
 
 		logger.Debug(ctx, "Received prediction in iteration %d: %v", i+1, prediction)
+		carryForwardNativeState(state, prediction)
 		step := ReActTraceStep{
 			Index:   i + 1,
 			Thought: stringifyPredictionField(prediction, "thought"),
@@ -437,6 +438,17 @@ func stringifyActionField(actionField interface{}) string {
 		}
 	}
 	return fmt.Sprint(actionField)
+}
+
+func carryForwardNativeState(state map[string]interface{}, prediction map[string]interface{}) {
+	if state == nil || prediction == nil {
+		return
+	}
+	for key, value := range prediction {
+		if strings.HasPrefix(key, "_native_") {
+			state[key] = value
+		}
+	}
 }
 
 // appendReActFields adds the standard ReAct fields (thought, action, observation)


### PR DESCRIPTION
## Summary
- preserve Gemini 3 thought signatures across native tool-calling turns
- add Gemini multi-turn GenerateWithTools support for tool loops
- carry hidden native tool state across ReAct iterations

## Validation
- go test ./pkg/llms ./pkg/interceptors ./pkg/modules ./pkg/agents/react
- go test ./pkg/agents/... ./pkg/llms ./pkg/interceptors ./pkg/modules
- golangci-lint run ./...