### PR TITLE
GEPA: ground reflection in evaluation evidence

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -313,6 +313,7 @@ type GEPAState struct {
 	ExecutionTraces          map[string][]ExecutionTrace       `json:"execution_traces"`
 	CandidateMetrics         map[string]*CandidateMetrics      `json:"candidate_metrics"`
 	MultiObjectiveFitnessMap map[string]*MultiObjectiveFitness `json:"multi_objective_fitness_map"`
+	candidateEvaluations     map[string]*gepaCandidateEvaluation
 
 	// Pareto archive for elite solution management
 	ParetoArchive     []*GEPACandidate                  `json:"pareto_archive"`
@@ -334,6 +335,7 @@ func NewGEPAState() *GEPAState {
 		ExecutionTraces:          make(map[string][]ExecutionTrace),
 		CandidateMetrics:         make(map[string]*CandidateMetrics),
 		MultiObjectiveFitnessMap: make(map[string]*MultiObjectiveFitness),
+		candidateEvaluations:     make(map[string]*gepaCandidateEvaluation),
 		ParetoArchive:            make([]*GEPACandidate, 0),
 		ArchiveFitnessMap:        make(map[string]*MultiObjectiveFitness),
 		MaxArchiveSize:           50, // Configurable archive size
@@ -394,6 +396,36 @@ func (s *GEPAState) GetTracesForCandidate(candidateID string) []ExecutionTrace {
 	}
 
 	return traces
+}
+
+// SetCandidateEvaluations replaces the latest candidate evaluation cache for the
+// current generation. Reflection consumes this to build example-grounded
+// prompts without re-running candidate evaluation.
+func (s *GEPAState) SetCandidateEvaluations(evaluations map[string]*gepaCandidateEvaluation) {
+	if s == nil {
+		return
+	}
+
+	cloned := make(map[string]*gepaCandidateEvaluation, len(evaluations))
+	for candidateID, evaluation := range evaluations {
+		cloned[candidateID] = cloneGEPACandidateEvaluation(evaluation)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.candidateEvaluations = cloned
+}
+
+// GetCandidateEvaluation returns the cached evaluation for a candidate from the
+// latest evaluated generation.
+func (s *GEPAState) GetCandidateEvaluation(candidateID string) *gepaCandidateEvaluation {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneGEPACandidateEvaluation(s.candidateEvaluations[candidateID])
 }
 
 // UpdateParetoArchive maintains elite Pareto-optimal solutions across generations.
@@ -4394,6 +4426,7 @@ func (g *GEPA) evaluatePopulation(ctx context.Context, program core.Program, dat
 	var mu sync.Mutex
 	evaluatedCount := 0
 	multiObjFitnessMap := make(map[string]*MultiObjectiveFitness)
+	candidateEvaluations := make(map[string]*gepaCandidateEvaluation, len(population.Candidates))
 
 	for _, candidate := range population.Candidates {
 		candidate := candidate // Capture loop variable
@@ -4407,6 +4440,7 @@ func (g *GEPA) evaluatePopulation(ctx context.Context, program core.Program, dat
 			mu.Lock()
 			candidate.Fitness = fitness
 			evaluatedCount++
+			candidateEvaluations[candidate.ID] = evaluation
 
 			// Get multi-objective fitness from candidate metrics
 			if metrics := g.performanceLogger.GetCandidateMetrics(candidate.ID); metrics != nil {
@@ -4436,6 +4470,7 @@ func (g *GEPA) evaluatePopulation(ctx context.Context, program core.Program, dat
 	}
 
 	p.Wait()
+	g.state.SetCandidateEvaluations(candidateEvaluations)
 
 	logger.Info(ctx, "Population evaluation completed: generation=%d, best_fitness=%.3f, evaluated_candidates=%d, multi_objective_entries=%d",
 		population.Generation,
@@ -4510,11 +4545,12 @@ func (g *GEPA) performReflection(ctx context.Context, generation int) error {
 
 	for _, candidate := range population.Candidates {
 		traces := g.state.GetTracesForCandidate(candidate.ID)
-		if len(traces) == 0 {
-			continue // Skip candidates with no execution traces
+		evaluation := g.state.GetCandidateEvaluation(candidate.ID)
+		if len(traces) == 0 && evaluation == nil {
+			continue // Skip candidates with no reflection evidence
 		}
 
-		reflection, err := g.reflectOnCandidate(ctx, candidate, traces)
+		reflection, err := g.reflectOnCandidate(ctx, candidate, evaluation, traces)
 		if err != nil {
 			logger.Error(ctx, "Failed to reflect on candidate %s: %v",
 				candidate.ID, err)
@@ -4538,13 +4574,14 @@ func (g *GEPA) performReflection(ctx context.Context, generation int) error {
 
 // reflectOnCandidate performs reflection analysis on a single candidate.
 func (g *GEPA) reflectOnCandidate(ctx context.Context, candidate *GEPACandidate,
-	traces []ExecutionTrace) (*ReflectionResult, error) {
+	evaluation *gepaCandidateEvaluation, traces []ExecutionTrace) (*ReflectionResult, error) {
 
 	// Analyze execution patterns
 	patterns := g.analyzeExecutionPatterns(traces)
+	reflectionInput := g.buildReflectionInput(evaluation)
 
 	// Generate reflection prompt
-	prompt := g.buildReflectionPrompt(candidate, patterns)
+	prompt := g.buildReflectionPrompt(candidate, patterns, reflectionInput)
 
 	// Get reflection from LLM
 	response, err := g.reflectionLLM.Generate(ctx, prompt)
@@ -4608,11 +4645,12 @@ func (g *GEPA) analyzeExecutionPatterns(traces []ExecutionTrace) *ExecutionPatte
 }
 
 // buildReflectionPrompt creates a reflection prompt for a candidate.
-func (g *GEPA) buildReflectionPrompt(candidate *GEPACandidate, patterns *ExecutionPatterns) string {
+func (g *GEPA) buildReflectionPrompt(candidate *GEPACandidate, patterns *ExecutionPatterns, reflectionInput *gepaReflectionInput) string {
 	richTraceEvidence := "none recorded"
 	if len(patterns.RichTraceEvidence) > 0 {
 		richTraceEvidence = "- " + strings.Join(patterns.RichTraceEvidence, "\n- ")
 	}
+	caseEvidence := g.formatReflectionCaseEvidence(reflectionInput)
 
 	return fmt.Sprintf(`As an expert prompt engineer, critically analyze this instruction and its performance:
 
@@ -4630,11 +4668,14 @@ EXECUTION PATTERNS:
 RICH TRACE EVIDENCE:
 %s
 
+EXAMPLE-LEVEL EVIDENCE:
+%s
+
 Please provide a detailed self-reflection covering:
 
 1. STRENGTHS: What aspects of this instruction work well?
-2. WEAKNESSES: What specific issues limit its effectiveness? Use the rich trace evidence section to ground concrete failure modes, loops, mismatches, and termination behavior.
-3. IMPROVEMENT SUGGESTIONS: Concrete ways to enhance this instruction based on the execution patterns and rich trace evidence.
+2. WEAKNESSES: What specific issues limit its effectiveness? Use the rich trace evidence and example-level evidence sections to ground concrete failure modes, loops, mismatches, bad outputs, and error cases.
+3. IMPROVEMENT SUGGESTIONS: Concrete ways to enhance this instruction based on the execution patterns, rich trace evidence, and example-level evidence.
 4. CONFIDENCE: Rate your confidence in this analysis (0.0-1.0)
 
 Format your response as:
@@ -4661,7 +4702,8 @@ CONFIDENCE: [0.0-1.0]`,
 		patterns.AverageResponseTime,
 		strings.Join(patterns.CommonFailures, ", "),
 		strings.Join(patterns.QualityIndicators, ", "),
-		richTraceEvidence)
+		richTraceEvidence,
+		caseEvidence)
 }
 
 // parseReflectionResponse parses the LLM reflection response.

--- a/pkg/optimizers/gepa_evaluation_adapter.go
+++ b/pkg/optimizers/gepa_evaluation_adapter.go
@@ -110,3 +110,52 @@ func (g *GEPA) evaluateCandidateWithAdapter(ctx context.Context, candidate *GEPA
 
 	return result
 }
+
+func cloneGEPACandidateEvaluation(evaluation *gepaCandidateEvaluation) *gepaCandidateEvaluation {
+	if evaluation == nil {
+		return nil
+	}
+
+	cloned := &gepaCandidateEvaluation{
+		AverageScore: evaluation.AverageScore,
+	}
+	if evaluation.Candidate != nil {
+		cloned.Candidate = CloneCandidate(evaluation.Candidate)
+	}
+	if len(evaluation.Cases) > 0 {
+		cloned.Cases = make([]gepaEvaluationCase, len(evaluation.Cases))
+		for i, evalCase := range evaluation.Cases {
+			cloned.Cases[i] = gepaEvaluationCase{
+				Example: cloneEvaluationExample(evalCase.Example),
+				Outputs: cloneStringAnyMap(evalCase.Outputs),
+				Score:   evalCase.Score,
+				Err:     evalCase.Err,
+			}
+		}
+	}
+
+	return cloned
+}
+
+func cloneEvaluationExample(example core.Example) core.Example {
+	return core.Example{
+		Inputs:  cloneStringAnyMap(example.Inputs),
+		Outputs: cloneStringAnyMap(example.Outputs),
+	}
+}
+
+func cloneStringAnyMap(values map[string]interface{}) map[string]interface{} {
+	if len(values) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]interface{}, len(values))
+	for key, value := range values {
+		// This is intentionally a shallow value copy. Evaluation examples and
+		// outputs currently hold scalar/string-like values, and reflection only
+		// needs map isolation rather than recursive deep-copying.
+		cloned[key] = value
+	}
+
+	return cloned
+}

--- a/pkg/optimizers/gepa_reflection_adapter.go
+++ b/pkg/optimizers/gepa_reflection_adapter.go
@@ -1,0 +1,165 @@
+package optimizers
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	maxReflectionWorstCases = 3
+	maxReflectionBestCases  = 1
+	maxReflectionValueChars = 220
+)
+
+type gepaReflectionCaseEvidence struct {
+	InputSummary    string
+	ExpectedSummary string
+	OutputSummary   string
+	ErrorSummary    string
+	Score           float64
+}
+
+// gepaReflectionInput adapts example-level candidate evaluation into a compact
+// prompt-oriented structure for reflection. This keeps reflection grounded in
+// concrete failed/successful cases without changing the outer optimization loop.
+type gepaReflectionInput struct {
+	TotalCases   int
+	SuccessCount int
+	FailureCount int
+	AverageScore float64
+	WorstCases   []gepaReflectionCaseEvidence
+	BestCases    []gepaReflectionCaseEvidence
+}
+
+func (g *GEPA) buildReflectionInput(evaluation *gepaCandidateEvaluation) *gepaReflectionInput {
+	if evaluation == nil || len(evaluation.Cases) == 0 {
+		return nil
+	}
+
+	result := &gepaReflectionInput{
+		TotalCases:   len(evaluation.Cases),
+		AverageScore: evaluation.AverageScore,
+	}
+
+	type rankedCase struct {
+		evidence gepaReflectionCaseEvidence
+		errRank  int
+	}
+
+	ranked := make([]rankedCase, 0, len(evaluation.Cases))
+	for _, evalCase := range evaluation.Cases {
+		evidence := gepaReflectionCaseEvidence{
+			InputSummary:    summarizeReflectionMap(evalCase.Example.Inputs),
+			ExpectedSummary: summarizeReflectionMap(evalCase.Example.Outputs),
+			OutputSummary:   summarizeReflectionMap(evalCase.Outputs),
+			Score:           evalCase.Score,
+		}
+		if evalCase.Err != nil {
+			evidence.ErrorSummary = truncateEvidence(evalCase.Err.Error(), maxReflectionValueChars)
+			result.FailureCount++
+		} else {
+			evidence.ErrorSummary = "none"
+			result.SuccessCount++
+		}
+
+		errRank := 0
+		if evalCase.Err != nil {
+			errRank = 1
+		}
+		ranked = append(ranked, rankedCase{
+			evidence: evidence,
+			errRank:  errRank,
+		})
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].errRank != ranked[j].errRank {
+			return ranked[i].errRank > ranked[j].errRank
+		}
+		if ranked[i].evidence.Score != ranked[j].evidence.Score {
+			return ranked[i].evidence.Score < ranked[j].evidence.Score
+		}
+		return ranked[i].evidence.InputSummary < ranked[j].evidence.InputSummary
+	})
+
+	for i := 0; i < len(ranked) && i < maxReflectionWorstCases; i++ {
+		result.WorstCases = append(result.WorstCases, ranked[i].evidence)
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].evidence.Score != ranked[j].evidence.Score {
+			return ranked[i].evidence.Score > ranked[j].evidence.Score
+		}
+		return ranked[i].evidence.InputSummary < ranked[j].evidence.InputSummary
+	})
+
+	for _, rankedCase := range ranked {
+		if rankedCase.errRank != 0 {
+			continue
+		}
+		result.BestCases = append(result.BestCases, rankedCase.evidence)
+		if len(result.BestCases) >= maxReflectionBestCases {
+			break
+		}
+	}
+
+	return result
+}
+
+func (g *GEPA) formatReflectionCaseEvidence(input *gepaReflectionInput) string {
+	if input == nil || input.TotalCases == 0 {
+		return "none recorded"
+	}
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "- Cases Evaluated: %d\n", input.TotalCases)
+	fmt.Fprintf(&builder, "- Successful Cases: %d\n", input.SuccessCount)
+	fmt.Fprintf(&builder, "- Error Cases: %d\n", input.FailureCount)
+	fmt.Fprintf(&builder, "- Average Case Score: %.3f\n", input.AverageScore)
+
+	if len(input.WorstCases) > 0 {
+		builder.WriteString("\nWorst Cases:\n")
+		for i, evidence := range input.WorstCases {
+			fmt.Fprintf(&builder,
+				"%d. Inputs: %s\n   Expected: %s\n   Actual: %s\n   Score: %.3f\n   Error: %s\n",
+				i+1,
+				evidence.InputSummary,
+				evidence.ExpectedSummary,
+				evidence.OutputSummary,
+				evidence.Score,
+				evidence.ErrorSummary,
+			)
+		}
+	}
+
+	if len(input.BestCases) > 0 {
+		builder.WriteString("\nRepresentative Successes:\n")
+		for i, evidence := range input.BestCases {
+			fmt.Fprintf(&builder,
+				"%d. Inputs: %s\n   Expected: %s\n   Actual: %s\n   Score: %.3f\n",
+				i+1,
+				evidence.InputSummary,
+				evidence.ExpectedSummary,
+				evidence.OutputSummary,
+				evidence.Score,
+			)
+		}
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func summarizeReflectionMap(values map[string]interface{}) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+
+	content, err := json.Marshal(values)
+	if err != nil {
+		return truncateEvidence(fmt.Sprintf("%v", values), maxReflectionValueChars)
+	}
+
+	return truncateEvidence(string(content), maxReflectionValueChars)
+}

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -606,6 +606,11 @@ func TestEvaluatePopulationSnapshotsBatchOnce(t *testing.T) {
 	assert.Equal(t, 1.0, candidate1.Fitness)
 	assert.Equal(t, 0.0, candidate2.Fitness)
 
+	storedEvaluation := gepa.state.GetCandidateEvaluation(candidate1.ID)
+	require.NotNil(t, storedEvaluation)
+	require.Len(t, storedEvaluation.Cases, 2)
+	assert.Equal(t, 1.0, storedEvaluation.AverageScore)
+
 	resetCalls, nextCalls := dataset.counts()
 	assert.Equal(t, 1, resetCalls)
 	assert.Equal(t, 2, nextCalls)
@@ -1134,13 +1139,13 @@ func TestReflectionEngine(t *testing.T) {
 	assert.Equal(t, 0.5, patterns.SuccessRate)
 
 	// Test reflection prompt building
-	prompt := gepa.buildReflectionPrompt(candidate, patterns)
+	prompt := gepa.buildReflectionPrompt(candidate, patterns, nil)
 	assert.Contains(t, prompt, candidate.Instruction)
 	assert.Contains(t, prompt, "STRENGTHS")
 	assert.Contains(t, prompt, "WEAKNESSES")
 
 	// Test reflection on candidate
-	reflection, err := gepa.reflectOnCandidate(ctx, candidate, traces)
+	reflection, err := gepa.reflectOnCandidate(ctx, candidate, nil, traces)
 	require.NoError(t, err)
 	assert.Equal(t, candidate.ID, reflection.CandidateID)
 }
@@ -1184,10 +1189,97 @@ func TestReflectionEngine_UsesRichTraceEvidence(t *testing.T) {
 	assert.Contains(t, patterns.RichTraceEvidence, "termination=max_iterations (seen 1x)")
 	assert.Contains(t, patterns.RichTraceEvidence, "failed_test=output:answer (seen 1x)")
 
-	prompt := gepa.buildReflectionPrompt(candidate, patterns)
+	prompt := gepa.buildReflectionPrompt(candidate, patterns, nil)
 	assert.Contains(t, prompt, "RICH TRACE EVIDENCE:")
 	assert.Contains(t, prompt, "termination=max_iterations (seen 1x)")
 	assert.Contains(t, prompt, "failed_test=output:answer (seen 1x)")
+}
+
+func TestBuildReflectionPromptIncludesExampleLevelEvidence(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+	}
+
+	candidate := &GEPACandidate{
+		ID:          "reflection-evidence-candidate",
+		ModuleName:  "alpha",
+		Instruction: "Return the tuned answer.",
+		Fitness:     0.4,
+		Generation:  2,
+	}
+	patterns := &ExecutionPatterns{
+		SuccessRate:         0.5,
+		SuccessCount:        1,
+		TotalExecutions:     2,
+		AverageResponseTime: 120 * time.Millisecond,
+		CommonFailures:      []string{"comparison_error"},
+		QualityIndicators:   []string{"variable_performance"},
+		RichTraceEvidence:   []string{"termination=max_iterations (seen 1x)"},
+	}
+	evaluation := &gepaCandidateEvaluation{
+		Candidate: candidate,
+		Cases: []gepaEvaluationCase{
+			{
+				Example: core.Example{
+					Inputs:  map[string]interface{}{"question": "What is DSPy?"},
+					Outputs: map[string]interface{}{"output": "framework"},
+				},
+				Outputs: map[string]interface{}{"output": "wrong"},
+				Score:   0.0,
+				Err:     fmt.Errorf("comparison failed"),
+			},
+			{
+				Example: core.Example{
+					Inputs:  map[string]interface{}{"question": "What is GEPA?"},
+					Outputs: map[string]interface{}{"output": "optimizer"},
+				},
+				Outputs: map[string]interface{}{"output": "optimizer"},
+				Score:   1.0,
+			},
+		},
+		AverageScore: 0.5,
+	}
+
+	reflectionInput := gepa.buildReflectionInput(evaluation)
+	require.NotNil(t, reflectionInput)
+	prompt := gepa.buildReflectionPrompt(candidate, patterns, reflectionInput)
+
+	assert.Contains(t, prompt, "EXAMPLE-LEVEL EVIDENCE:")
+	assert.Contains(t, prompt, "Worst Cases:")
+	assert.Contains(t, prompt, `{"question":"What is DSPy?"}`)
+	assert.Contains(t, prompt, `{"output":"wrong"}`)
+	assert.Contains(t, prompt, "Representative Successes:")
+	assert.Contains(t, prompt, `{"question":"What is GEPA?"}`)
+}
+
+func TestBuildReflectionInputBoundsWorstCases(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+	}
+
+	cases := make([]gepaEvaluationCase, 0, 5)
+	for i := 0; i < 5; i++ {
+		cases = append(cases, gepaEvaluationCase{
+			Example: core.Example{
+				Inputs:  map[string]interface{}{"question": fmt.Sprintf("q-%d", i)},
+				Outputs: map[string]interface{}{"output": fmt.Sprintf("expected-%d", i)},
+			},
+			Outputs: map[string]interface{}{"output": fmt.Sprintf("actual-%d", i)},
+			Score:   float64(i) / 10.0,
+		})
+	}
+
+	reflectionInput := gepa.buildReflectionInput(&gepaCandidateEvaluation{
+		Cases:        cases,
+		AverageScore: 0.2,
+	})
+	require.NotNil(t, reflectionInput)
+	assert.Len(t, reflectionInput.WorstCases, maxReflectionWorstCases)
+	assert.Len(t, reflectionInput.BestCases, maxReflectionBestCases)
+	assert.Equal(t, `{"question":"q-0"}`, reflectionInput.WorstCases[0].InputSummary)
+	assert.Equal(t, `{"question":"q-4"}`, reflectionInput.BestCases[0].InputSummary)
 }
 
 func TestSelfCritiqueSystem(t *testing.T) {


### PR DESCRIPTION
## Summary
- cache per-candidate evaluation results in GEPA state during population evaluation
- add a reflection adapter that turns evaluation cases into bounded example-level evidence for prompts
- update reflection tests to avoid leaked global default-LLM state and verify bounded evidence selection

## Testing
- go test ./pkg/optimizers/... -v -count=1 -run 'TestBuildReflectionPromptIncludesExampleLevelEvidence|TestBuildReflectionInputBoundsWorstCases' -timeout 60s
- go test ./pkg/optimizers ./pkg/agents/optimize
- go test ./...
- golangci-lint run ./...