### PR TITLE
GEPA: gate proposals on minibatch improvements

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -724,6 +724,12 @@ type GEPA struct {
 	generationLLM core.LLM
 	reflectionLLM core.LLM
 
+	// Latest stable minibatch adapter from the current generation. Mutation
+	// proposals can use this to do candidate-level accept/reject before they
+	// enter the next generation.
+	evaluationAdapterMu     sync.RWMutex
+	latestEvaluationAdapter *gepaEvaluationAdapter
+
 	// Interceptor integration
 	interceptorChain *core.InterceptorChain
 
@@ -4269,10 +4275,18 @@ func (g *GEPA) mutate(ctx context.Context, candidate *GEPACandidate) *GEPACandid
 	}
 
 	if proposed := g.reflectionGuidedMutation(ctx, candidate); proposed != nil {
-		return proposed
+		if proposed == candidate {
+			return candidate
+		}
+		return g.acceptMutationProposal(ctx, candidate, proposed)
 	}
 
-	return g.semanticMutation(ctx, candidate)
+	proposed := g.semanticMutation(ctx, candidate)
+	if proposed == candidate {
+		return candidate
+	}
+
+	return g.acceptMutationProposal(ctx, candidate, proposed)
 }
 
 // semanticMutation performs LLM-based semantic mutation.
@@ -4455,6 +4469,7 @@ func (g *GEPA) evaluatePopulation(ctx context.Context, program core.Program, dat
 		len(population.Candidates))
 
 	adapter := g.newEvaluationAdapter(program, dataset, metric)
+	g.setLatestEvaluationAdapter(adapter)
 
 	// Use concurrent evaluation with controlled concurrency
 	p := pool.New().WithMaxGoroutines(g.config.ConcurrencyLevel)

--- a/pkg/optimizers/gepa_acceptance_adapter.go
+++ b/pkg/optimizers/gepa_acceptance_adapter.go
@@ -1,0 +1,91 @@
+package optimizers
+
+import "context"
+
+func (g *GEPA) setLatestEvaluationAdapter(adapter *gepaEvaluationAdapter) {
+	if g == nil {
+		return
+	}
+
+	g.evaluationAdapterMu.Lock()
+	defer g.evaluationAdapterMu.Unlock()
+	g.latestEvaluationAdapter = adapter
+}
+
+func (g *GEPA) getLatestEvaluationAdapter() *gepaEvaluationAdapter {
+	if g == nil {
+		return nil
+	}
+
+	g.evaluationAdapterMu.RLock()
+	defer g.evaluationAdapterMu.RUnlock()
+	return g.latestEvaluationAdapter
+}
+
+func (g *GEPA) acceptMutationProposal(ctx context.Context, baseline, proposed *GEPACandidate) *GEPACandidate {
+	if baseline == nil || proposed == nil {
+		if proposed != nil {
+			return proposed
+		}
+		return baseline
+	}
+	if baseline == proposed {
+		return baseline
+	}
+
+	adapter := g.getLatestEvaluationAdapter()
+	if adapter == nil {
+		return proposed
+	}
+
+	baselineEvaluation := g.cachedOrEvaluateCandidate(ctx, baseline, adapter)
+	proposedEvaluation := g.evaluateCandidateWithAdapter(ctx, proposed, adapter)
+	if proposedEvaluation == nil {
+		return baseline
+	}
+
+	if baselineEvaluation != nil && totalScoreFromEvaluation(proposedEvaluation) <= totalScoreFromEvaluation(baselineEvaluation) {
+		return baseline
+	}
+
+	proposed.Fitness = proposedEvaluation.AverageScore
+	proposed.Metadata = mergeCandidateMetadata(map[string]interface{}{
+		"proposal_accepted":          true,
+		"proposal_baseline_total":    totalScoreFromEvaluation(baselineEvaluation),
+		"proposal_candidate_total":   totalScoreFromEvaluation(proposedEvaluation),
+		"proposal_baseline_average":  averageScoreFromEvaluation(baselineEvaluation),
+		"proposal_candidate_average": proposedEvaluation.AverageScore,
+	}, proposed.Metadata)
+
+	return proposed
+}
+
+func (g *GEPA) cachedOrEvaluateCandidate(ctx context.Context, candidate *GEPACandidate, adapter *gepaEvaluationAdapter) *gepaCandidateEvaluation {
+	if candidate == nil {
+		return nil
+	}
+
+	if g != nil && g.state != nil {
+		if evaluation := g.state.GetCandidateEvaluation(candidate.ID); evaluation != nil {
+			return evaluation
+		}
+	}
+
+	return g.evaluateCandidateWithAdapter(ctx, candidate, adapter)
+}
+
+func totalScoreFromEvaluation(evaluation *gepaCandidateEvaluation) float64 {
+	if evaluation == nil {
+		return 0.0
+	}
+
+	return evaluation.TotalScore
+}
+
+func averageScoreFromEvaluation(evaluation *gepaCandidateEvaluation) float64 {
+	if evaluation == nil {
+		return 0.0
+	}
+
+	return evaluation.AverageScore
+}

--- a/pkg/optimizers/gepa_evaluation_adapter.go
+++ b/pkg/optimizers/gepa_evaluation_adapter.go
@@ -21,6 +21,7 @@ type gepaEvaluationCase struct {
 type gepaCandidateEvaluation struct {
 	Candidate    *GEPACandidate
 	Cases        []gepaEvaluationCase
+	TotalScore   float64
 	AverageScore float64
 }
 
@@ -105,6 +106,7 @@ func (g *GEPA) evaluateCandidateWithAdapter(ctx context.Context, candidate *GEPA
 	}
 
 	if scoredCases > 0 {
+		result.TotalScore = totalScore
 		result.AverageScore = totalScore / float64(scoredCases)
 	}
 
@@ -117,6 +119,7 @@ func cloneGEPACandidateEvaluation(evaluation *gepaCandidateEvaluation) *gepaCand
 	}
 
 	cloned := &gepaCandidateEvaluation{
+		TotalScore:   evaluation.TotalScore,
 		AverageScore: evaluation.AverageScore,
 	}
 	if evaluation.Candidate != nil {

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -470,6 +470,7 @@ func TestEvaluateCandidateWithAdapterCapturesExampleResults(t *testing.T) {
 	evaluation := gepa.evaluateCandidateWithAdapter(context.Background(), candidate, adapter)
 	require.NotNil(t, evaluation)
 	assert.Equal(t, candidate, evaluation.Candidate)
+	assert.Equal(t, 2.0, evaluation.TotalScore)
 	assert.Equal(t, 1.0, evaluation.AverageScore)
 	require.Len(t, evaluation.Cases, 2)
 	for _, evalCase := range evaluation.Cases {
@@ -609,11 +610,197 @@ func TestEvaluatePopulationSnapshotsBatchOnce(t *testing.T) {
 	storedEvaluation := gepa.state.GetCandidateEvaluation(candidate1.ID)
 	require.NotNil(t, storedEvaluation)
 	require.Len(t, storedEvaluation.Cases, 2)
+	assert.Equal(t, 2.0, storedEvaluation.TotalScore)
 	assert.Equal(t, 1.0, storedEvaluation.AverageScore)
 
 	resetCalls, nextCalls := dataset.counts()
 	assert.Equal(t, 1, resetCalls)
 	assert.Equal(t, 2, nextCalls)
+}
+
+func TestMutateAcceptsImprovingProposalOnMinibatch(t *testing.T) {
+	mockLLM := &testutil.MockLLM{}
+	mockLLM.On("Generate", mock.Anything, mock.Anything, mock.Anything).Return(&core.LLMResponse{
+		Content: "alpha tuned",
+	}, nil)
+
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			MutationRate:        1.0,
+			EvaluationBatchSize: 2,
+		},
+		state:         NewGEPAState(),
+		generationLLM: mockLLM,
+		rng:           rand.New(rand.NewSource(1)),
+	}
+
+	baseline := &GEPACandidate{
+		ID:          "baseline",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		Fitness:     0.0,
+	}
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "alpha tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned"}},
+	})
+	adapter := gepa.newEvaluationAdapter(newCandidateEvaluationTestProgram("alpha base"), dataset, exactOutputMetric)
+	gepa.setLatestEvaluationAdapter(adapter)
+	gepa.state.SetCandidateEvaluations(map[string]*gepaCandidateEvaluation{
+		baseline.ID: gepa.evaluateCandidateWithAdapter(context.Background(), baseline, adapter),
+	})
+
+	mutated := gepa.mutate(context.Background(), baseline)
+	require.NotNil(t, mutated)
+	assert.NotEqual(t, baseline.ID, mutated.ID)
+	assert.Equal(t, "alpha tuned", mutated.Instruction)
+	assert.Equal(t, 1.0, mutated.Fitness)
+	assert.Equal(t, true, mutated.Metadata["proposal_accepted"])
+	assert.Equal(t, 0.0, mutated.Metadata["proposal_baseline_total"])
+	assert.Equal(t, 2.0, mutated.Metadata["proposal_candidate_total"])
+	assert.Equal(t, 0.0, mutated.Metadata["proposal_baseline_average"])
+	assert.Equal(t, 1.0, mutated.Metadata["proposal_candidate_average"])
+}
+
+func TestMutateRejectsNonImprovingProposalOnMinibatch(t *testing.T) {
+	mockLLM := &testutil.MockLLM{}
+	mockLLM.On("Generate", mock.Anything, mock.Anything, mock.Anything).Return(&core.LLMResponse{
+		Content: "alpha worse",
+	}, nil)
+
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			MutationRate:        1.0,
+			EvaluationBatchSize: 2,
+		},
+		state:         NewGEPAState(),
+		generationLLM: mockLLM,
+		rng:           rand.New(rand.NewSource(1)),
+	}
+
+	baseline := &GEPACandidate{
+		ID:          "baseline",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		Fitness:     1.0,
+	}
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "alpha base"}},
+		{Outputs: map[string]interface{}{"output": "alpha base"}},
+	})
+	adapter := gepa.newEvaluationAdapter(newCandidateEvaluationTestProgram("alpha base"), dataset, exactOutputMetric)
+	gepa.setLatestEvaluationAdapter(adapter)
+	gepa.state.SetCandidateEvaluations(map[string]*gepaCandidateEvaluation{
+		baseline.ID: gepa.evaluateCandidateWithAdapter(context.Background(), baseline, adapter),
+	})
+
+	mutated := gepa.mutate(context.Background(), baseline)
+	require.NotNil(t, mutated)
+	assert.Same(t, baseline, mutated)
+	assert.Equal(t, "alpha base", mutated.Instruction)
+}
+
+func TestMutateSkipsAcceptanceForNoOpFallbackMutation(t *testing.T) {
+	mockLLM := &testutil.MockLLM{}
+	mockLLM.On("Generate", mock.Anything, mock.Anything, mock.Anything).Return((*core.LLMResponse)(nil), fmt.Errorf("boom"))
+
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			MutationRate:        1.0,
+			EvaluationBatchSize: 2,
+		},
+		state:         NewGEPAState(),
+		generationLLM: mockLLM,
+		rng:           rand.New(rand.NewSource(1)),
+	}
+
+	executeCalls := 0
+	program := core.NewProgramWithForwardFactory(map[string]core.Module{
+		"alpha": newStaticCandidateTestModule(""),
+	}, func(modules map[string]core.Module) func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+		return func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+			executeCalls++
+			return map[string]interface{}{"output": modules["alpha"].GetSignature().Instruction}, nil
+		}
+	})
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": ""}},
+	})
+	gepa.setLatestEvaluationAdapter(gepa.newEvaluationAdapter(program, dataset, exactOutputMetric))
+
+	baseline := &GEPACandidate{
+		ID:          "empty",
+		ModuleName:  "alpha",
+		Instruction: "",
+	}
+
+	mutated := gepa.mutate(context.Background(), baseline)
+	assert.Same(t, baseline, mutated)
+	assert.Equal(t, 0, executeCalls)
+}
+
+func TestMutateAcceptsProposalUsingTotalScoreWhenAverageWouldReject(t *testing.T) {
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			EvaluationBatchSize: 2,
+		},
+		state: NewGEPAState(),
+	}
+
+	program := core.NewProgramWithForwardFactory(map[string]core.Module{
+		"alpha": newStaticCandidateTestModule("fragile"),
+	}, func(modules map[string]core.Module) func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+		return func(_ context.Context, inputs map[string]interface{}) (map[string]interface{}, error) {
+			instruction := modules["alpha"].GetSignature().Instruction
+			if instruction == "fragile" && inputs["case"] == "hard" {
+				return nil, fmt.Errorf("hard-case failure")
+			}
+			return map[string]interface{}{"output": "ok"}, nil
+		}
+	})
+	weightedMetric := func(expected, actual map[string]interface{}) float64 {
+		if expected["output"] != actual["output"] {
+			return 0.0
+		}
+		return expected["weight"].(float64)
+	}
+	dataset := newCountingDataset([]core.Example{
+		{
+			Inputs:  map[string]interface{}{"case": "easy"},
+			Outputs: map[string]interface{}{"output": "ok", "weight": 1.0},
+		},
+		{
+			Inputs:  map[string]interface{}{"case": "hard"},
+			Outputs: map[string]interface{}{"output": "ok", "weight": 0.6},
+		},
+	})
+	adapter := gepa.newEvaluationAdapter(program, dataset, weightedMetric)
+	gepa.setLatestEvaluationAdapter(adapter)
+
+	baseline := &GEPACandidate{
+		ID:          "fragile-parent",
+		ModuleName:  "alpha",
+		Instruction: "fragile",
+	}
+	proposed := &GEPACandidate{
+		ID:          "robust-child",
+		ModuleName:  "alpha",
+		Instruction: "robust instruction",
+	}
+	gepa.state.SetCandidateEvaluations(map[string]*gepaCandidateEvaluation{
+		baseline.ID: gepa.evaluateCandidateWithAdapter(context.Background(), baseline, adapter),
+	})
+
+	accepted := gepa.acceptMutationProposal(context.Background(), baseline, proposed)
+	require.NotNil(t, accepted)
+	assert.Same(t, proposed, accepted)
+	assert.Equal(t, "robust instruction", accepted.Instruction)
+	assert.Equal(t, 1.6, accepted.Metadata["proposal_candidate_total"])
+	assert.Equal(t, 1.0, accepted.Metadata["proposal_baseline_total"])
+	assert.Equal(t, 0.8, accepted.Metadata["proposal_candidate_average"])
+	assert.Equal(t, 1.0, accepted.Metadata["proposal_baseline_average"])
 }
 
 func TestMaterializeEvaluationBatchUsesSingleExampleForNonPositiveBatchSize(t *testing.T) {


### PR DESCRIPTION
## Summary
- cache the current generation's stable minibatch evaluation adapter for proposal admission checks
- gate mutation proposals on same-minibatch improvement before they enter the next generation
- compare summed minibatch case scores, treating errored cases as zero, and add regression coverage for no-op fallback and total-vs-average acceptance behavior

## Testing
- go test ./pkg/optimizers -run 'TestMutateAcceptsImprovingProposalOnMinibatch|TestMutateRejectsNonImprovingProposalOnMinibatch|TestMutateSkipsAcceptanceForNoOpFallbackMutation|TestMutateAcceptsProposalUsingTotalScoreWhenAverageWouldReject|TestEvaluateCandidateWithAdapterCapturesExampleResults|TestEvaluatePopulationSnapshotsBatchOnce' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- go test ./...
- golangci-lint run ./...