### PR TITLE
GEPA: evaluate whole-program candidate state

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -177,9 +177,8 @@ func deriveBaseComponentTexts(base map[string]string, moduleName, instruction st
 	if componentTexts == nil {
 		componentTexts = make(map[string]string, 1)
 	}
-	// Non-target component texts are lineage bookkeeping until GEPA switches to
-	// whole-program candidate evaluation. Mutations/crossovers therefore inherit
-	// the source candidate's view and update only the targeted module here.
+	// GEPA candidates carry the full program instruction map. Mutations update
+	// one selected component while preserving the rest of the candidate state.
 	componentTexts[moduleName] = instruction
 	return componentTexts
 }
@@ -222,6 +221,23 @@ func componentTextsFromProgram(program core.Program) map[string]string {
 	}
 
 	return componentTexts
+}
+
+func componentModuleNames(componentTexts map[string]string) []string {
+	if len(componentTexts) == 0 {
+		return nil
+	}
+
+	moduleNames := make([]string, 0, len(componentTexts))
+	for moduleName := range componentTexts {
+		moduleName = strings.TrimSpace(moduleName)
+		if moduleName == "" {
+			continue
+		}
+		moduleNames = append(moduleNames, moduleName)
+	}
+	sort.Strings(moduleNames)
+	return moduleNames
 }
 
 // Population represents a generation of prompt candidates.
@@ -3897,8 +3913,9 @@ func (g *GEPA) proposeNextGenerationCandidate(ctx context.Context, source *GEPAC
 		return nil
 	}
 
-	proposed := g.mutate(ctx, source)
-	if proposed == nil || proposed == source {
+	focusedSource := g.prepareCandidateForComponentUpdate(source)
+	proposed := g.mutate(ctx, focusedSource)
+	if proposed == nil || proposed == source || proposed == focusedSource {
 		carried := g.copyCandidate(source)
 		carried.Generation = nextGeneration
 		return carried
@@ -3909,6 +3926,35 @@ func (g *GEPA) proposeNextGenerationCandidate(ctx context.Context, source *GEPAC
 	}
 
 	return proposed
+}
+
+func (g *GEPA) prepareCandidateForComponentUpdate(source *GEPACandidate) *GEPACandidate {
+	if source == nil {
+		return nil
+	}
+
+	moduleName := g.selectComponentForUpdate(source)
+	focused := g.copyCandidate(source)
+	focused.ModuleName = moduleName
+	focused.Instruction = candidateInstructionForModule(source, moduleName)
+	return focused
+}
+
+func (g *GEPA) selectComponentForUpdate(candidate *GEPACandidate) string {
+	if candidate == nil {
+		return ""
+	}
+
+	moduleNames := componentModuleNames(cloneCandidateComponentTexts(candidate))
+	if len(moduleNames) == 0 {
+		return strings.TrimSpace(candidate.ModuleName)
+	}
+
+	// The current whole-program refactor keeps component focus selection simple:
+	// choose one module uniformly at random from the candidate state. This keeps
+	// the iterative update path lightweight for now; round-robin or "update all"
+	// strategies can layer on top of the same whole-program candidate model later.
+	return moduleNames[g.rng.Intn(len(moduleNames))]
 }
 
 // selectCandidates returns candidates sampled according to the configured
@@ -4546,13 +4592,17 @@ func (g *GEPA) applyComponentTexts(program core.Program, componentTexts map[stri
 	return modified
 }
 
-// applyCandidate applies only the candidate's target module during evaluation.
-// Until GEPA candidates become true whole-program states, non-target component
-// texts are lineage bookkeeping and should not overwrite other independently
-// tuned modules during fitness measurement.
+// applyCandidate applies the candidate's whole-program instruction state during
+// evaluation. ModuleName/Instruction remain the focused component for the
+// current update step, while ComponentTexts is the authoritative program state.
 func (g *GEPA) applyCandidate(program core.Program, candidate *GEPACandidate) core.Program {
 	if candidate == nil {
 		return program.Clone()
+	}
+
+	componentTexts := cloneCandidateComponentTexts(candidate)
+	if len(componentTexts) > 0 {
+		return g.applyComponentTexts(program, componentTexts)
 	}
 
 	moduleName := strings.TrimSpace(candidate.ModuleName)
@@ -4565,9 +4615,7 @@ func (g *GEPA) applyCandidate(program core.Program, candidate *GEPACandidate) co
 		return program.Clone()
 	}
 
-	return g.applyComponentTexts(program, map[string]string{
-		moduleName: instruction,
-	})
+	return g.applyComponentTexts(program, map[string]string{moduleName: instruction})
 }
 
 // Reflection Engine
@@ -5103,7 +5151,11 @@ func (g *GEPA) hasConverged() bool {
 	return false
 }
 
-// applyBestCandidate applies the best candidate to the final program.
+// applyBestCandidate applies the best whole-program candidate to the final
+// program. This intentionally prefers a coherent candidate state over the older
+// "best module from anywhere in history" composition, matching whole-program
+// GEPA semantics even when that means a module-specific local winner from a
+// different candidate is not stitched into the final result.
 func (g *GEPA) applyBestCandidate(program core.Program) core.Program {
 	if g.state.BestCandidate == nil {
 		logging.GetLogger().Warn(context.Background(), "No best candidate found, returning original program")
@@ -5116,56 +5168,7 @@ func (g *GEPA) applyBestCandidate(program core.Program) core.Program {
 		g.state.BestCandidate.Fitness,
 		g.state.BestCandidate.Instruction)
 
-	bestByModule := g.bestCandidatesByModule()
-	if len(bestByModule) == 0 {
-		return g.applyCandidate(program, g.state.BestCandidate)
-	}
-
-	componentTexts := make(map[string]string, len(bestByModule))
-	for moduleName, candidate := range bestByModule {
-		instruction := candidateInstructionForModule(candidate, moduleName)
-		if instruction == "" {
-			continue
-		}
-		componentTexts[moduleName] = instruction
-	}
-
-	return g.applyComponentTexts(program, componentTexts)
-}
-
-func (g *GEPA) bestCandidatesByModule() map[string]*GEPACandidate {
-	bestByModule := make(map[string]*GEPACandidate)
-
-	g.state.mu.RLock()
-	defer g.state.mu.RUnlock()
-
-	for _, population := range g.state.PopulationHistory {
-		if population == nil {
-			continue
-		}
-
-		for _, candidate := range population.Candidates {
-			if candidate == nil || strings.TrimSpace(candidate.ModuleName) == "" {
-				continue
-			}
-
-			currentBest, exists := bestByModule[candidate.ModuleName]
-			if !exists || candidate.Fitness > currentBest.Fitness {
-				bestByModule[candidate.ModuleName] = candidate
-			}
-		}
-	}
-
-	if len(bestByModule) == 0 && g.state.BestCandidate != nil && strings.TrimSpace(g.state.BestCandidate.ModuleName) != "" {
-		bestByModule[g.state.BestCandidate.ModuleName] = g.state.BestCandidate
-	}
-
-	clonedBestByModule := make(map[string]*GEPACandidate, len(bestByModule))
-	for moduleName, candidate := range bestByModule {
-		clonedBestByModule[moduleName] = g.copyCandidate(candidate)
-	}
-
-	return clonedBestByModule
+	return g.applyCandidate(program, g.state.BestCandidate)
 }
 
 // LLM-based Self-Critique Implementation

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -237,6 +237,19 @@ func newCandidateEvaluationTestProgram(instruction string) core.Program {
 	})
 }
 
+func newTwoModuleCandidateEvaluationTestProgram(alphaInstruction, betaInstruction string) core.Program {
+	return core.NewProgramWithForwardFactory(map[string]core.Module{
+		"alpha": newStaticCandidateTestModule(alphaInstruction),
+		"beta":  newStaticCandidateTestModule(betaInstruction),
+	}, func(modules map[string]core.Module) func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+		return func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"output": modules["alpha"].GetSignature().Instruction + "|" + modules["beta"].GetSignature().Instruction,
+			}, nil
+		}
+	})
+}
+
 func exactOutputMetric(expected, actual map[string]interface{}) float64 {
 	if expected["output"] == actual["output"] {
 		return 1.0
@@ -400,7 +413,7 @@ func TestPopulationManagement(t *testing.T) {
 	}
 }
 
-func TestApplyCandidateOnlyUpdatesTargetModule(t *testing.T) {
+func TestApplyCandidateAppliesWholeProgramComponentTexts(t *testing.T) {
 	gepa := &GEPA{state: NewGEPAState()}
 
 	program := core.Program{
@@ -422,7 +435,7 @@ func TestApplyCandidateOnlyUpdatesTargetModule(t *testing.T) {
 
 	modified := gepa.applyCandidate(program, candidate)
 	assert.Equal(t, "alpha tuned", modified.Modules["alpha"].GetSignature().Instruction)
-	assert.Equal(t, "beta base", modified.Modules["beta"].GetSignature().Instruction)
+	assert.Equal(t, "beta tuned", modified.Modules["beta"].GetSignature().Instruction)
 }
 
 func TestNewEvaluationAdapterSnapshotsBatchOnce(t *testing.T) {
@@ -501,33 +514,23 @@ func TestCandidateInstructionForModule(t *testing.T) {
 	assert.Equal(t, "alpha inline", candidateInstructionForModule(inlineOnly, "alpha"))
 }
 
-func TestApplyBestCandidateComposesBestModuleCandidates(t *testing.T) {
+func TestApplyBestCandidateUsesWholeProgramState(t *testing.T) {
 	gepa := &GEPA{state: NewGEPAState()}
 
-	alphaBest := &GEPACandidate{
-		ID:          "alpha-best",
+	bestCandidate := &GEPACandidate{
+		ID:          "best-whole-program",
 		ModuleName:  "alpha",
 		Instruction: "alpha tuned",
 		ComponentTexts: map[string]string{
 			"alpha": "alpha tuned",
-			"beta":  "beta base",
+			"beta":  "beta tuned",
 		},
 		Fitness: 0.9,
 	}
-	betaBest := &GEPACandidate{
-		ID:          "beta-best",
-		ModuleName:  "beta",
-		Instruction: "beta tuned",
-		ComponentTexts: map[string]string{
-			"alpha": "alpha base",
-			"beta":  "beta tuned",
-		},
-		Fitness: 0.8,
-	}
 
-	gepa.state.BestCandidate = alphaBest
+	gepa.state.BestCandidate = bestCandidate
 	gepa.state.PopulationHistory = []*Population{{
-		Candidates: []*GEPACandidate{alphaBest, betaBest},
+		Candidates: []*GEPACandidate{bestCandidate},
 	}}
 
 	program := core.Program{
@@ -540,6 +543,36 @@ func TestApplyBestCandidateComposesBestModuleCandidates(t *testing.T) {
 	modified := gepa.applyBestCandidate(program)
 	assert.Equal(t, "alpha tuned", modified.Modules["alpha"].GetSignature().Instruction)
 	assert.Equal(t, "beta tuned", modified.Modules["beta"].GetSignature().Instruction)
+}
+
+func TestEvaluateCandidateWithAdapterUsesWholeProgramComponentTexts(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+	}
+	gepa.config.EvaluationBatchSize = 1
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+	})
+	adapter := gepa.newEvaluationAdapter(newTwoModuleCandidateEvaluationTestProgram("alpha base", "beta base"), dataset, exactOutputMetric)
+
+	candidate := &GEPACandidate{
+		ID:          "whole-program-candidate",
+		ModuleName:  "alpha",
+		Instruction: "alpha tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha tuned",
+			"beta":  "beta tuned",
+		},
+	}
+
+	evaluation := gepa.evaluateCandidateWithAdapter(context.Background(), candidate, adapter)
+	require.NotNil(t, evaluation)
+	assert.Equal(t, 1.0, evaluation.TotalScore)
+	assert.Equal(t, 1.0, evaluation.AverageScore)
+	require.Len(t, evaluation.Cases, 1)
+	assert.Equal(t, "alpha tuned|beta tuned", evaluation.Cases[0].Outputs["output"])
 }
 
 func TestEvaluatePopulationSnapshotsBatchOnce(t *testing.T) {
@@ -842,28 +875,6 @@ func TestCompileMaterializesDatasetOnceForIterativeLoop(t *testing.T) {
 	resetCalls, nextCalls := dataset.counts()
 	assert.Equal(t, 1, resetCalls)
 	assert.Equal(t, 2, nextCalls)
-}
-
-func TestBestCandidatesByModuleReturnsCopies(t *testing.T) {
-	gepa := &GEPA{state: NewGEPAState()}
-
-	alphaBest := &GEPACandidate{
-		ID:          "alpha-best",
-		ModuleName:  "alpha",
-		Instruction: "alpha tuned",
-		Fitness:     0.9,
-	}
-	gepa.state.BestCandidate = alphaBest
-	gepa.state.PopulationHistory = []*Population{{
-		Candidates: []*GEPACandidate{alphaBest},
-	}}
-
-	bestByModule := gepa.bestCandidatesByModule()
-	require.Contains(t, bestByModule, "alpha")
-	assert.NotSame(t, alphaBest, bestByModule["alpha"])
-
-	bestByModule["alpha"].Instruction = "mutated outside state"
-	assert.Equal(t, "alpha tuned", alphaBest.Instruction)
 }
 
 func TestEvolutionaryOperators(t *testing.T) {


### PR DESCRIPTION
## Summary
- make ComponentTexts the authoritative whole-program candidate state during evaluation
- select one component from the whole-program candidate for each iterative update step while keeping the existing proposal/reflection prompts focused
- apply the best whole-program candidate directly at the end instead of composing per-module winners from history

## Testing
- go test ./pkg/optimizers -run 'TestApplyCandidateAppliesWholeProgramComponentTexts|TestEvaluateCandidateWithAdapterUsesWholeProgramComponentTexts|TestApplyBestCandidateUsesWholeProgramState|TestEvolvePopulationUsesCandidateCentricProposalLoop|TestCompileMaterializesDatasetOnceForIterativeLoop|TestMutateAcceptsImprovingProposalOnMinibatch|TestMutateRejectsNonImprovingProposalOnMinibatch|TestEvolvePopulationPreservesFitnessMapForUpdatedCandidates' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- go test ./...
- golangci-lint run ./...