### PR TITLE
GEPA: add validation-guided candidate tracking

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -90,8 +90,10 @@ type GEPAConfig struct {
 	StagnationLimit      int     `json:"stagnation_limit"`      // Default: 3
 
 	// Performance parameters
-	EvaluationBatchSize int `json:"evaluation_batch_size"` // Default: 5
-	ConcurrencyLevel    int `json:"concurrency_level"`     // Default: 3
+	EvaluationBatchSize int     `json:"evaluation_batch_size"` // Default: 5
+	ConcurrencyLevel    int     `json:"concurrency_level"`     // Default: 3
+	ValidationFrequency int     `json:"validation_frequency"`  // Default: 1
+	ValidationSplit     float64 `json:"validation_split"`      // Default: 0.0 (disabled)
 
 	// LLM parameters
 	GenerationModel string  `json:"generation_model"` // Default: uses core.GetDefaultLLM()
@@ -117,6 +119,8 @@ func DefaultGEPAConfig() *GEPAConfig {
 		StagnationLimit:      3,
 		EvaluationBatchSize:  5,
 		ConcurrencyLevel:     3,
+		ValidationFrequency:  1,
+		ValidationSplit:      0.0,
 		Temperature:          0.8,
 		MaxTokens:            500,
 	}
@@ -321,6 +325,8 @@ type GEPAState struct {
 	CurrentGeneration        int                               `json:"current_generation"`
 	BestCandidate            *GEPACandidate                    `json:"best_candidate"`
 	BestFitness              float64                           `json:"best_fitness"`
+	BestValidationCandidate  *GEPACandidate                    `json:"best_validation_candidate,omitempty"`
+	BestValidationFitness    float64                           `json:"best_validation_fitness"`
 	PopulationHistory        []*Population                     `json:"population_history"`
 	ReflectionHistory        []*ReflectionResult               `json:"reflection_history"`
 	ConvergenceStatus        *ConvergenceStatus                `json:"convergence_status"`
@@ -331,6 +337,7 @@ type GEPAState struct {
 	MultiObjectiveFitnessMap map[string]*MultiObjectiveFitness `json:"multi_objective_fitness_map"`
 	candidateReflections     map[string]*ReflectionResult
 	candidateEvaluations     map[string]*gepaCandidateEvaluation
+	candidateValidationEvals map[string]*gepaCandidateEvaluation
 
 	// Pareto archive for elite solution management
 	ParetoArchive     []*GEPACandidate                  `json:"pareto_archive"`
@@ -345,6 +352,7 @@ func NewGEPAState() *GEPAState {
 	return &GEPAState{
 		CurrentGeneration:        0,
 		BestFitness:              0.0,
+		BestValidationFitness:    math.Inf(-1),
 		PopulationHistory:        make([]*Population, 0),
 		ReflectionHistory:        make([]*ReflectionResult, 0),
 		StartTime:                time.Now(),
@@ -354,6 +362,7 @@ func NewGEPAState() *GEPAState {
 		MultiObjectiveFitnessMap: make(map[string]*MultiObjectiveFitness),
 		candidateReflections:     make(map[string]*ReflectionResult),
 		candidateEvaluations:     make(map[string]*gepaCandidateEvaluation),
+		candidateValidationEvals: make(map[string]*gepaCandidateEvaluation),
 		ParetoArchive:            make([]*GEPACandidate, 0),
 		ArchiveFitnessMap:        make(map[string]*MultiObjectiveFitness),
 		MaxArchiveSize:           50, // Configurable archive size
@@ -474,6 +483,39 @@ func (s *GEPAState) GetCandidateEvaluation(candidateID string) *gepaCandidateEva
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return cloneGEPACandidateEvaluation(s.candidateEvaluations[candidateID])
+}
+
+// SetCandidateValidationEvaluations replaces the current validation-evaluation
+// cache. Validation selection and final candidate choice consult this
+// separately from minibatch/training evaluations.
+func (s *GEPAState) SetCandidateValidationEvaluations(evaluations map[string]*gepaCandidateEvaluation) {
+	if s == nil {
+		return
+	}
+
+	var cloned map[string]*gepaCandidateEvaluation
+	if len(evaluations) > 0 {
+		cloned = make(map[string]*gepaCandidateEvaluation, len(evaluations))
+		for candidateID, evaluation := range evaluations {
+			cloned[candidateID] = cloneGEPACandidateEvaluation(evaluation)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.candidateValidationEvals = cloned
+}
+
+// GetCandidateValidationEvaluation returns the cached validation evaluation for
+// a candidate from the latest validation pass.
+func (s *GEPAState) GetCandidateValidationEvaluation(candidateID string) *gepaCandidateEvaluation {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneGEPACandidateEvaluation(s.candidateValidationEvals[candidateID])
 }
 
 // UpsertCandidateEvaluation updates the cached evaluation for a single
@@ -2756,6 +2798,15 @@ func NewGEPA(config *GEPAConfig) (*GEPA, error) {
 	if config.EvaluationBatchSize <= 0 {
 		config.EvaluationBatchSize = defaults.EvaluationBatchSize
 	}
+	if config.ValidationFrequency <= 0 {
+		config.ValidationFrequency = defaults.ValidationFrequency
+	}
+	if config.ValidationSplit < 0 {
+		config.ValidationSplit = defaults.ValidationSplit
+	}
+	if config.ValidationSplit > 1 {
+		config.ValidationSplit = 0.9
+	}
 	if config.TournamentSize <= 0 {
 		config.TournamentSize = defaults.TournamentSize
 	}
@@ -2839,13 +2890,27 @@ func (g *GEPA) runIterativeOptimizationLoop(ctx context.Context, program core.Pr
 		return fmt.Errorf("optimizers: max generations must be positive")
 	}
 
+	trainDataset, validationExamples, err := g.prepareOptimizationDatasets(dataset)
+	if err != nil {
+		return err
+	}
+	g.resetValidationState()
+	lastValidatedGeneration := -1
+
 	if err := g.initializePopulation(ctx, program); err != nil {
 		return fmt.Errorf("failed to initialize population: %w", err)
 	}
 
 	g.state.CurrentGeneration = 0
-	if err := g.evaluateAndArchiveCurrentPopulation(ctx, program, dataset, metric); err != nil {
+	if err := g.evaluateAndArchiveCurrentPopulation(ctx, program, trainDataset, metric); err != nil {
 		return fmt.Errorf("evaluation failed at generation 0: %w", err)
+	}
+	validated, err := g.validateIfScheduled(ctx, program, metric, validationExamples, 0)
+	if err != nil {
+		return fmt.Errorf("validation failed at generation 0: %w", err)
+	}
+	if validated {
+		lastValidatedGeneration = 0
 	}
 	if err := g.reflectIfScheduled(ctx, 0); err != nil {
 		logger.Error(ctx, "reflection failed at generation 0: %v", err)
@@ -2871,6 +2936,13 @@ func (g *GEPA) runIterativeOptimizationLoop(ctx context.Context, program core.Pr
 		if currentPop != nil {
 			g.state.UpdateParetoArchive(currentPop.Candidates, g.getCurrentMultiObjectiveFitnessMap())
 		}
+		validated, err := g.validateIfScheduled(ctx, program, metric, validationExamples, generation)
+		if err != nil {
+			return fmt.Errorf("validation failed at generation %d: %w", generation, err)
+		}
+		if validated {
+			lastValidatedGeneration = generation
+		}
 		if err := g.reflectIfScheduled(ctx, generation); err != nil {
 			logger.Error(ctx, "reflection failed at generation %d: %v", generation, err)
 		}
@@ -2880,6 +2952,12 @@ func (g *GEPA) runIterativeOptimizationLoop(ctx context.Context, program core.Pr
 		if g.hasConverged() {
 			logger.Info(ctx, "Convergence achieved at generation %d", generation)
 			break
+		}
+	}
+
+	if len(validationExamples) > 0 && lastValidatedGeneration != g.state.CurrentGeneration {
+		if err := g.evaluateValidationPopulation(ctx, program, validationExamples, metric); err != nil {
+			return fmt.Errorf("final validation failed: %w", err)
 		}
 	}
 
@@ -2899,6 +2977,160 @@ func (g *GEPA) evaluateAndArchiveCurrentPopulation(ctx context.Context, program 
 	}
 
 	return nil
+}
+
+func (g *GEPA) prepareOptimizationDatasets(dataset core.Dataset) (core.Dataset, []core.Example, error) {
+	if dataset == nil || g.config.ValidationSplit <= 0 {
+		return dataset, nil, nil
+	}
+
+	allExamples := core.DatasetToSlice(dataset)
+	if len(allExamples) <= 1 {
+		return newGEPAExampleDataset(allExamples), nil, nil
+	}
+
+	allExamples = cloneEvaluationExamples(allExamples)
+	rng := g.rng
+	if rng == nil {
+		rng = rand.New(rand.NewSource(0))
+	}
+	// Validation uses a shuffled holdout slice so ordered datasets do not bias the
+	// tail examples into becoming the validation set by construction.
+	rng.Shuffle(len(allExamples), func(i, j int) {
+		allExamples[i], allExamples[j] = allExamples[j], allExamples[i]
+	})
+
+	validationCount := int(math.Ceil(float64(len(allExamples)) * g.config.ValidationSplit))
+	if validationCount >= len(allExamples) {
+		validationCount = len(allExamples) - 1
+	}
+	if validationCount <= 0 {
+		return newGEPAExampleDataset(allExamples), nil, nil
+	}
+
+	split := len(allExamples) - validationCount
+	trainExamples := allExamples[:split]
+	validationExamples := allExamples[split:]
+	if len(trainExamples) == 0 {
+		return nil, nil, fmt.Errorf("optimizers: validation split consumed all training examples")
+	}
+
+	return newGEPAExampleDataset(trainExamples), validationExamples, nil
+}
+
+func (g *GEPA) validateIfScheduled(ctx context.Context, program core.Program, metric core.Metric, validationExamples []core.Example, generation int) (bool, error) {
+	if len(validationExamples) == 0 {
+		return false, nil
+	}
+	frequency := g.config.ValidationFrequency
+	if frequency <= 0 {
+		frequency = 1
+	}
+	if generation != 0 && generation%frequency != 0 {
+		return false, nil
+	}
+	return true, g.evaluateValidationPopulation(ctx, program, validationExamples, metric)
+}
+
+func (g *GEPA) resetValidationState() {
+	if g == nil || g.state == nil {
+		return
+	}
+
+	g.state.mu.Lock()
+	defer g.state.mu.Unlock()
+	g.state.candidateValidationEvals = make(map[string]*gepaCandidateEvaluation)
+	g.state.BestValidationCandidate = nil
+	g.state.BestValidationFitness = math.Inf(-1)
+}
+
+func (g *GEPA) evaluateValidationPopulation(ctx context.Context, program core.Program, validationExamples []core.Example, metric core.Metric) error {
+	if len(validationExamples) == 0 {
+		g.resetValidationState()
+		return nil
+	}
+
+	population := g.getCurrentPopulation()
+	if population == nil {
+		return fmt.Errorf("no current population to validate")
+	}
+
+	logger := logging.GetLogger()
+	logger.Info(ctx, "Validating population: generation=%d, candidates=%d, examples=%d",
+		population.Generation,
+		len(population.Candidates),
+		len(validationExamples))
+
+	adapter := g.newEvaluationAdapterForExamples(program, validationExamples, metric)
+	p := pool.New().WithMaxGoroutines(g.config.ConcurrencyLevel)
+
+	var mu sync.Mutex
+	bestFitness := math.Inf(-1)
+	var bestCandidate *GEPACandidate
+	candidateEvaluations := make(map[string]*gepaCandidateEvaluation, len(population.Candidates))
+	recordValidationEvaluation := func(candidate *GEPACandidate, evaluation *gepaCandidateEvaluation) {
+		if candidate == nil || evaluation == nil {
+			return
+		}
+
+		score := evaluation.AverageScore
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		candidateEvaluations[candidate.ID] = evaluation
+		if bestCandidate == nil || score > bestFitness || (score == bestFitness && candidate.ID < bestCandidate.ID) {
+			bestCandidate = g.copyCandidate(candidate)
+			bestFitness = score
+			if bestCandidate.Metadata == nil {
+				bestCandidate.Metadata = make(map[string]interface{})
+			}
+			bestCandidate.Metadata["validation_score"] = score
+		}
+	}
+
+	for _, candidate := range population.Candidates {
+		if candidate == nil {
+			continue
+		}
+
+		if cachedEvaluation := g.state.GetCandidateValidationEvaluation(candidate.ID); cachedEvaluation != nil {
+			recordValidationEvaluation(candidate, cachedEvaluation)
+			continue
+		}
+
+		candidate := candidate
+		p.Go(func() {
+			evaluation := g.evaluateCandidateWithAdapter(ctx, candidate, adapter)
+			recordValidationEvaluation(candidate, evaluation)
+		})
+	}
+
+	p.Wait()
+	g.state.SetCandidateValidationEvaluations(candidateEvaluations)
+	g.setBestValidationCandidate(bestCandidate, bestFitness)
+
+	logger.Info(ctx, "Validation completed: generation=%d, evaluated_candidates=%d, best_validation_fitness=%.3f",
+		population.Generation,
+		len(candidateEvaluations),
+		bestFitness)
+
+	return nil
+}
+
+func (g *GEPA) setBestValidationCandidate(candidate *GEPACandidate, fitness float64) {
+	if g == nil || g.state == nil || candidate == nil || math.IsInf(fitness, -1) {
+		return
+	}
+
+	g.state.mu.Lock()
+	defer g.state.mu.Unlock()
+
+	if g.state.BestValidationCandidate == nil || fitness > g.state.BestValidationFitness ||
+		(fitness == g.state.BestValidationFitness && candidate.ID < g.state.BestValidationCandidate.ID) {
+		g.state.BestValidationCandidate = CloneCandidate(candidate)
+		g.state.BestValidationFitness = fitness
+	}
 }
 
 func (g *GEPA) reflectIfScheduled(ctx context.Context, generation int) error {
@@ -3574,6 +3806,13 @@ func (g *GEPA) logOptimizationResults(ctx context.Context) {
 			g.state.BestCandidate.Fitness,
 			g.state.BestCandidate.Instruction)
 	}
+	if g.state.BestValidationCandidate != nil {
+		logger.Info(ctx, "Best validation candidate found: id=%s, generation=%d, validation_fitness=%.3f, instruction=%s",
+			g.state.BestValidationCandidate.ID,
+			g.state.BestValidationCandidate.Generation,
+			g.state.BestValidationFitness,
+			g.state.BestValidationCandidate.Instruction)
+	}
 }
 
 // Population Management Methods
@@ -3988,6 +4227,10 @@ func (g *GEPA) selectCandidates(population *Population, count int) []*GEPACandid
 }
 
 func (g *GEPA) selectCandidateForUpdate(population *Population) *GEPACandidate {
+	if selected := g.selectValidationCandidateForUpdate(population); selected != nil {
+		return selected
+	}
+
 	selected := g.selectCandidates(population, 1)
 	if len(selected) > 0 && selected[0] != nil {
 		return selected[0]
@@ -3996,6 +4239,123 @@ func (g *GEPA) selectCandidateForUpdate(population *Population) *GEPACandidate {
 		return nil
 	}
 	return population.Candidates[g.rng.Intn(len(population.Candidates))]
+}
+
+func (g *GEPA) selectValidationCandidateForUpdate(population *Population) *GEPACandidate {
+	validationPopulation, validationFitnessMap, ok := g.validationSelectionPopulation(population)
+	if !ok {
+		return nil
+	}
+
+	var selected []*GEPACandidate
+	switch g.config.SelectionStrategy {
+	case "roulette":
+		selected = g.rouletteSelection(validationPopulation, 1)
+	case "pareto":
+		selected = g.selectWithParetoRanking(validationPopulation.Candidates, validationFitnessMap, 1)
+	case "adaptive_pareto":
+		selected = g.adaptiveParetoSelectionWithFitnessMap(validationPopulation, validationFitnessMap, 1)
+	default:
+		selected = g.tournamentSelection(validationPopulation, 1)
+	}
+
+	if len(selected) == 0 || selected[0] == nil {
+		return nil
+	}
+
+	return g.findPopulationCandidateByID(population, selected[0].ID)
+}
+
+func (g *GEPA) validationSelectionPopulation(population *Population) (*Population, map[string]*MultiObjectiveFitness, bool) {
+	if population == nil || len(population.Candidates) == 0 {
+		return nil, nil, false
+	}
+
+	validationPopulation := &Population{
+		Candidates:  make([]*GEPACandidate, 0, len(population.Candidates)),
+		Generation:  population.Generation,
+		BestFitness: math.Inf(-1),
+	}
+	validationFitnessMap := make(map[string]*MultiObjectiveFitness, len(population.Candidates))
+	currentFitnessMap := g.getCurrentMultiObjectiveFitnessMap()
+
+	for _, candidate := range population.Candidates {
+		if candidate == nil {
+			continue
+		}
+
+		evaluation := g.state.GetCandidateValidationEvaluation(candidate.ID)
+		if evaluation == nil {
+			return nil, nil, false
+		}
+
+		cloned := g.copyCandidate(candidate)
+		cloned.Fitness = evaluation.AverageScore
+		validationPopulation.Candidates = append(validationPopulation.Candidates, cloned)
+		validationFitnessMap[candidate.ID] = validationAdjustedMultiObjectiveFitness(currentFitnessMap[candidate.ID], evaluation.AverageScore)
+
+		if validationPopulation.BestCandidate == nil || cloned.Fitness > validationPopulation.BestFitness || (cloned.Fitness == validationPopulation.BestFitness && cloned.ID < validationPopulation.BestCandidate.ID) {
+			validationPopulation.BestCandidate = cloned
+			validationPopulation.BestFitness = cloned.Fitness
+		}
+	}
+
+	if len(validationPopulation.Candidates) == 0 {
+		return nil, nil, false
+	}
+
+	return validationPopulation, validationFitnessMap, true
+}
+
+func validationAdjustedMultiObjectiveFitness(base *MultiObjectiveFitness, validationScore float64) *MultiObjectiveFitness {
+	fitness := &MultiObjectiveFitness{
+		SuccessRate:    validationScore,
+		OutputQuality:  validationScore,
+		Efficiency:     0.5,
+		Robustness:     0.5,
+		Generalization: 0.5,
+		Diversity:      0.5,
+		Innovation:     0.5,
+	}
+
+	if base != nil {
+		*fitness = *base
+		fitness.SuccessRate = validationScore
+	}
+
+	fitness.WeightedScore = fitness.ComputeWeightedScore(nil)
+	return fitness
+}
+
+func (g *GEPA) adaptiveParetoSelectionWithFitnessMap(population *Population, fitnessMap map[string]*MultiObjectiveFitness, selectionSize int) []*GEPACandidate {
+	if population == nil || len(population.Candidates) <= selectionSize {
+		return population.Candidates
+	}
+
+	diversityScore := g.assessPopulationDiversity(population.Candidates, fitnessMap)
+	convergenceProgress := float64(g.state.CurrentGeneration) / float64(g.config.MaxGenerations)
+
+	if diversityScore < 0.3 && convergenceProgress > 0.5 {
+		return g.adaptiveWeightedSelection(population.Candidates, fitnessMap, selectionSize, g.state.CurrentGeneration)
+	}
+	if convergenceProgress < 0.3 {
+		return g.diversityEnhancedParetoSelection(population.Candidates, fitnessMap, selectionSize)
+	}
+	return g.selectWithParetoRanking(population.Candidates, fitnessMap, selectionSize)
+}
+
+func (g *GEPA) findPopulationCandidateByID(population *Population, candidateID string) *GEPACandidate {
+	if population == nil || strings.TrimSpace(candidateID) == "" {
+		return nil
+	}
+
+	for _, candidate := range population.Candidates {
+		if candidate != nil && candidate.ID == candidateID {
+			return candidate
+		}
+	}
+
+	return nil
 }
 
 func (g *GEPA) populationSnapshotWithReplacement(current *Population, sourceID string, replacement *GEPACandidate, generation int) (*Population, bool) {
@@ -5157,18 +5517,45 @@ func (g *GEPA) hasConverged() bool {
 // GEPA semantics even when that means a module-specific local winner from a
 // different candidate is not stitched into the final result.
 func (g *GEPA) applyBestCandidate(program core.Program) core.Program {
-	if g.state.BestCandidate == nil {
+	bestCandidate, bestFitness, usingValidation := g.bestCandidateForApplication()
+	if bestCandidate == nil {
 		logging.GetLogger().Warn(context.Background(), "No best candidate found, returning original program")
 		return program
 	}
 
 	logger := logging.GetLogger()
-	logger.Info(context.Background(), "Applying best candidate to program: id=%s, fitness=%.3f, instruction=%s",
-		g.state.BestCandidate.ID,
-		g.state.BestCandidate.Fitness,
-		g.state.BestCandidate.Instruction)
+	if usingValidation {
+		logger.Info(context.Background(), "Applying best validation candidate to program: id=%s, validation_fitness=%.3f, training_fitness=%.3f, instruction=%s",
+			bestCandidate.ID,
+			bestFitness,
+			bestCandidate.Fitness,
+			bestCandidate.Instruction)
+	} else {
+		logger.Info(context.Background(), "Applying best candidate to program: id=%s, fitness=%.3f, instruction=%s",
+			bestCandidate.ID,
+			bestCandidate.Fitness,
+			bestCandidate.Instruction)
+	}
 
-	return g.applyCandidate(program, g.state.BestCandidate)
+	return g.applyCandidate(program, bestCandidate)
+}
+
+func (g *GEPA) bestCandidateForApplication() (*GEPACandidate, float64, bool) {
+	if g == nil || g.state == nil {
+		return nil, 0, false
+	}
+
+	g.state.mu.RLock()
+	defer g.state.mu.RUnlock()
+
+	switch {
+	case g.state.BestValidationCandidate != nil:
+		return CloneCandidate(g.state.BestValidationCandidate), g.state.BestValidationFitness, true
+	case g.state.BestCandidate != nil:
+		return CloneCandidate(g.state.BestCandidate), g.state.BestFitness, false
+	default:
+		return nil, 0, false
+	}
 }
 
 // LLM-based Self-Critique Implementation

--- a/pkg/optimizers/gepa_evaluation_adapter.go
+++ b/pkg/optimizers/gepa_evaluation_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/datasets"
 )
 
 // gepaEvaluationCase captures one example-level evaluation. Future reflective
@@ -37,6 +38,18 @@ func (g *GEPA) newEvaluationAdapter(program core.Program, dataset core.Dataset, 
 		batch:       g.materializeEvaluationBatch(dataset),
 		metric:      metric,
 	}
+}
+
+func (g *GEPA) newEvaluationAdapterForExamples(program core.Program, examples []core.Example, metric core.Metric) *gepaEvaluationAdapter {
+	return &gepaEvaluationAdapter{
+		baseProgram: program,
+		batch:       cloneEvaluationExamples(examples),
+		metric:      metric,
+	}
+}
+
+func newGEPAExampleDataset(examples []core.Example) core.Dataset {
+	return datasets.NewSimpleDataset(examples)
 }
 
 func (g *GEPA) materializeEvaluationBatch(dataset core.Dataset) []core.Example {
@@ -137,6 +150,18 @@ func cloneGEPACandidateEvaluation(evaluation *gepaCandidateEvaluation) *gepaCand
 		}
 	}
 
+	return cloned
+}
+
+func cloneEvaluationExamples(examples []core.Example) []core.Example {
+	if len(examples) == 0 {
+		return nil
+	}
+
+	cloned := make([]core.Example, len(examples))
+	for i, example := range examples {
+		cloned[i] = cloneEvaluationExample(example)
+	}
 	return cloned
 }
 

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -3,6 +3,7 @@ package optimizers
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"strings"
 	"sync"
@@ -250,6 +251,19 @@ func newTwoModuleCandidateEvaluationTestProgram(alphaInstruction, betaInstructio
 	})
 }
 
+func newCountingCandidateEvaluationProgram(instruction string, executions *int) core.Program {
+	return core.NewProgramWithForwardFactory(map[string]core.Module{
+		"alpha": newStaticCandidateTestModule(instruction),
+	}, func(modules map[string]core.Module) func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+		return func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+			*executions = *executions + 1
+			return map[string]interface{}{
+				"output": modules["alpha"].GetSignature().Instruction,
+			}, nil
+		}
+	})
+}
+
 func exactOutputMetric(expected, actual map[string]interface{}) float64 {
 	if expected["output"] == actual["output"] {
 		return 1.0
@@ -347,9 +361,11 @@ func TestGEPAState(t *testing.T) {
 
 	assert.Equal(t, 0, state.CurrentGeneration)
 	assert.Equal(t, 0.0, state.BestFitness)
+	assert.True(t, math.IsInf(state.BestValidationFitness, -1))
 	assert.NotNil(t, state.PopulationHistory)
 	assert.NotNil(t, state.ExecutionTraces)
 	assert.NotNil(t, state.CandidateMetrics)
+	assert.NotNil(t, state.candidateValidationEvals)
 
 	// Test adding trace
 	trace := &ExecutionTrace{
@@ -545,6 +561,171 @@ func TestApplyBestCandidateUsesWholeProgramState(t *testing.T) {
 	assert.Equal(t, "beta tuned", modified.Modules["beta"].GetSignature().Instruction)
 }
 
+func TestApplyBestCandidatePrefersValidationWinner(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+	}
+
+	trainBest := &GEPACandidate{
+		ID:          "train-best",
+		ModuleName:  "alpha",
+		Instruction: "alpha train",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha train",
+			"beta":  "beta base",
+		},
+		Fitness: 0.95,
+	}
+	validationBest := &GEPACandidate{
+		ID:          "validation-best",
+		ModuleName:  "alpha",
+		Instruction: "alpha val",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha val",
+			"beta":  "beta val",
+		},
+		Fitness: 0.70,
+	}
+	gepa.state.BestCandidate = trainBest
+	gepa.state.BestValidationCandidate = validationBest
+	gepa.state.BestValidationFitness = 0.90
+	gepa.state.PopulationHistory = []*Population{{
+		Candidates: []*GEPACandidate{trainBest, validationBest},
+	}}
+	gepa.state.SetCandidateValidationEvaluations(map[string]*gepaCandidateEvaluation{
+		"train-best":      {AverageScore: 0.10},
+		"validation-best": {AverageScore: 0.90},
+	})
+
+	program := core.Program{
+		Modules: map[string]core.Module{
+			"alpha": newStaticCandidateTestModule("alpha base"),
+			"beta":  newStaticCandidateTestModule("beta base"),
+		},
+	}
+
+	modified := gepa.applyBestCandidate(program)
+	assert.Equal(t, "alpha val", modified.Modules["alpha"].GetSignature().Instruction)
+	assert.Equal(t, "beta val", modified.Modules["beta"].GetSignature().Instruction)
+}
+
+func TestPrepareOptimizationDatasetsUsesValidationSplit(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ValidationSplit = 0.4
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "one"}},
+		{Outputs: map[string]interface{}{"output": "two"}},
+		{Outputs: map[string]interface{}{"output": "three"}},
+		{Outputs: map[string]interface{}{"output": "four"}},
+		{Outputs: map[string]interface{}{"output": "five"}},
+	})
+
+	trainDataset, validationExamples, err := gepa.prepareOptimizationDatasets(dataset)
+	require.NoError(t, err)
+
+	trainExamples := core.DatasetToSlice(trainDataset)
+	require.Len(t, trainExamples, 3)
+	require.Len(t, validationExamples, 2)
+
+	seen := make(map[string]int)
+	for _, example := range trainExamples {
+		seen[example.Outputs["output"].(string)]++
+	}
+	for _, example := range validationExamples {
+		seen[example.Outputs["output"].(string)]++
+	}
+	assert.Len(t, seen, 5)
+	assert.Equal(t, 1, seen["one"])
+	assert.Equal(t, 1, seen["two"])
+	assert.Equal(t, 1, seen["three"])
+	assert.Equal(t, 1, seen["four"])
+	assert.Equal(t, 1, seen["five"])
+
+	validationOutputs := []string{
+		validationExamples[0].Outputs["output"].(string),
+		validationExamples[1].Outputs["output"].(string),
+	}
+	assert.NotEqual(t, []string{"four", "five"}, validationOutputs)
+}
+
+func TestPrepareOptimizationDatasetsDisabledValidationSplit(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+	}
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "one"}},
+		{Outputs: map[string]interface{}{"output": "two"}},
+	})
+
+	trainDataset, validationExamples, err := gepa.prepareOptimizationDatasets(dataset)
+	require.NoError(t, err)
+	assert.Same(t, dataset, trainDataset)
+	assert.Nil(t, validationExamples)
+}
+
+func TestPrepareOptimizationDatasetsBoundarySizes(t *testing.T) {
+	tests := []struct {
+		name             string
+		examples         []core.Example
+		validationSplit  float64
+		expectedTrainLen int
+		expectedValLen   int
+	}{
+		{
+			name:             "single example stays in train",
+			examples:         []core.Example{{Outputs: map[string]interface{}{"output": "one"}}},
+			validationSplit:  0.5,
+			expectedTrainLen: 1,
+			expectedValLen:   0,
+		},
+		{
+			name: "two examples split one and one",
+			examples: []core.Example{
+				{Outputs: map[string]interface{}{"output": "one"}},
+				{Outputs: map[string]interface{}{"output": "two"}},
+			},
+			validationSplit:  0.5,
+			expectedTrainLen: 1,
+			expectedValLen:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gepa := &GEPA{
+				config: DefaultGEPAConfig(),
+				state:  NewGEPAState(),
+				rng:    rand.New(rand.NewSource(1)),
+			}
+			gepa.config.ValidationSplit = tt.validationSplit
+
+			trainDataset, validationExamples, err := gepa.prepareOptimizationDatasets(newCountingDataset(tt.examples))
+			require.NoError(t, err)
+
+			trainExamples := core.DatasetToSlice(trainDataset)
+			assert.Len(t, trainExamples, tt.expectedTrainLen)
+			assert.Len(t, validationExamples, tt.expectedValLen)
+
+			seen := make(map[string]int)
+			for _, example := range trainExamples {
+				seen[example.Outputs["output"].(string)]++
+			}
+			for _, example := range validationExamples {
+				seen[example.Outputs["output"].(string)]++
+			}
+			assert.Len(t, seen, len(tt.examples))
+		})
+	}
+}
+
 func TestEvaluateCandidateWithAdapterUsesWholeProgramComponentTexts(t *testing.T) {
 	gepa := &GEPA{
 		config: DefaultGEPAConfig(),
@@ -573,6 +754,315 @@ func TestEvaluateCandidateWithAdapterUsesWholeProgramComponentTexts(t *testing.T
 	assert.Equal(t, 1.0, evaluation.AverageScore)
 	require.Len(t, evaluation.Cases, 1)
 	assert.Equal(t, "alpha tuned|beta tuned", evaluation.Cases[0].Outputs["output"])
+}
+
+func TestEvaluateValidationPopulationTracksBestValidationCandidate(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ConcurrencyLevel = 1
+
+	population := &Population{
+		Generation: 0,
+		Candidates: []*GEPACandidate{
+			{
+				ID:          "candidate-a",
+				ModuleName:  "alpha",
+				Instruction: "alpha a",
+				ComponentTexts: map[string]string{
+					"alpha": "alpha a",
+				},
+				Fitness: 0.5,
+			},
+			{
+				ID:          "candidate-b",
+				ModuleName:  "alpha",
+				Instruction: "alpha b",
+				ComponentTexts: map[string]string{
+					"alpha": "alpha b",
+				},
+				Fitness: 0.4,
+			},
+		},
+	}
+	gepa.state.PopulationHistory = []*Population{population}
+
+	err := gepa.evaluateValidationPopulation(
+		context.Background(),
+		newCandidateEvaluationTestProgram("alpha base"),
+		[]core.Example{{Outputs: map[string]interface{}{"output": "alpha b"}}},
+		exactOutputMetric,
+	)
+	require.NoError(t, err)
+
+	best := gepa.state.BestValidationCandidate
+	require.NotNil(t, best)
+	assert.Equal(t, "candidate-b", best.ID)
+	assert.Equal(t, 1.0, gepa.state.BestValidationFitness)
+	require.NotNil(t, gepa.state.GetCandidateValidationEvaluation("candidate-a"))
+	require.NotNil(t, gepa.state.GetCandidateValidationEvaluation("candidate-b"))
+}
+
+func TestEvaluateValidationPopulationReusesCachedEvaluations(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ConcurrencyLevel = 1
+
+	population := &Population{
+		Generation: 0,
+		Candidates: []*GEPACandidate{
+			{
+				ID:          "candidate-a",
+				ModuleName:  "alpha",
+				Instruction: "alpha a",
+				ComponentTexts: map[string]string{
+					"alpha": "alpha a",
+				},
+			},
+			{
+				ID:          "candidate-b",
+				ModuleName:  "alpha",
+				Instruction: "alpha b",
+				ComponentTexts: map[string]string{
+					"alpha": "alpha b",
+				},
+			},
+		},
+	}
+	gepa.state.PopulationHistory = []*Population{population}
+
+	executions := 0
+	program := newCountingCandidateEvaluationProgram("alpha base", &executions)
+	validationExamples := []core.Example{{Outputs: map[string]interface{}{"output": "alpha a"}}}
+
+	err := gepa.evaluateValidationPopulation(context.Background(), program, validationExamples, exactOutputMetric)
+	require.NoError(t, err)
+	assert.Equal(t, 2, executions)
+
+	err = gepa.evaluateValidationPopulation(context.Background(), program, validationExamples, exactOutputMetric)
+	require.NoError(t, err)
+	assert.Equal(t, 2, executions)
+}
+
+func TestEvaluateValidationPopulationHandlesMixedCachedAndUncachedCandidates(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ConcurrencyLevel = 2
+
+	population := &Population{
+		Generation: 1,
+		Candidates: []*GEPACandidate{
+			{
+				ID:          "candidate-a",
+				ModuleName:  "alpha",
+				Instruction: "alpha a",
+				ComponentTexts: map[string]string{
+					"alpha": "alpha a",
+				},
+			},
+			{
+				ID:          "candidate-b",
+				ModuleName:  "alpha",
+				Instruction: "alpha b",
+				ComponentTexts: map[string]string{
+					"alpha": "alpha b",
+				},
+			},
+		},
+	}
+	gepa.state.PopulationHistory = []*Population{population}
+	gepa.state.SetCandidateValidationEvaluations(map[string]*gepaCandidateEvaluation{
+		"candidate-a": {
+			AverageScore: 1.0,
+			Cases: []gepaEvaluationCase{
+				{Outputs: map[string]interface{}{"output": "alpha a"}, Score: 1.0},
+			},
+		},
+	})
+
+	executions := 0
+	program := newCountingCandidateEvaluationProgram("alpha base", &executions)
+	validationExamples := []core.Example{{Outputs: map[string]interface{}{"output": "alpha a"}}}
+
+	err := gepa.evaluateValidationPopulation(context.Background(), program, validationExamples, exactOutputMetric)
+	require.NoError(t, err)
+	assert.Equal(t, 1, executions)
+	require.NotNil(t, gepa.state.GetCandidateValidationEvaluation("candidate-a"))
+	require.NotNil(t, gepa.state.GetCandidateValidationEvaluation("candidate-b"))
+}
+
+func TestEvaluateValidationPopulationPreservesAllTimeBestValidationCandidate(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ConcurrencyLevel = 1
+
+	validationExamples := []core.Example{{Outputs: map[string]interface{}{"output": "alpha a"}}}
+	program := newCandidateEvaluationTestProgram("alpha base")
+
+	gepa.state.PopulationHistory = []*Population{{
+		Generation: 0,
+		Candidates: []*GEPACandidate{{
+			ID:          "candidate-a",
+			ModuleName:  "alpha",
+			Instruction: "alpha a",
+			ComponentTexts: map[string]string{
+				"alpha": "alpha a",
+			},
+		}},
+	}}
+	err := gepa.evaluateValidationPopulation(context.Background(), program, validationExamples, exactOutputMetric)
+	require.NoError(t, err)
+	require.NotNil(t, gepa.state.BestValidationCandidate)
+	assert.Equal(t, "candidate-a", gepa.state.BestValidationCandidate.ID)
+	assert.Equal(t, 1.0, gepa.state.BestValidationFitness)
+
+	gepa.state.PopulationHistory = []*Population{{
+		Generation: 1,
+		Candidates: []*GEPACandidate{{
+			ID:          "candidate-b",
+			ModuleName:  "alpha",
+			Instruction: "alpha b",
+			ComponentTexts: map[string]string{
+				"alpha": "alpha b",
+			},
+		}},
+	}}
+	err = gepa.evaluateValidationPopulation(context.Background(), program, validationExamples, exactOutputMetric)
+	require.NoError(t, err)
+	require.NotNil(t, gepa.state.BestValidationCandidate)
+	assert.Equal(t, "candidate-a", gepa.state.BestValidationCandidate.ID)
+	assert.Equal(t, 1.0, gepa.state.BestValidationFitness)
+}
+
+func TestValidateIfScheduledHonorsValidationFrequency(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ValidationFrequency = 2
+	gepa.config.ConcurrencyLevel = 1
+
+	candidate := &GEPACandidate{
+		ID:          "candidate-a",
+		ModuleName:  "alpha",
+		Instruction: "alpha a",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha a",
+		},
+	}
+	gepa.state.PopulationHistory = []*Population{{
+		Generation: 1,
+		Candidates: []*GEPACandidate{candidate},
+	}}
+
+	validated, err := gepa.validateIfScheduled(
+		context.Background(),
+		newCandidateEvaluationTestProgram("alpha base"),
+		exactOutputMetric,
+		[]core.Example{{Outputs: map[string]interface{}{"output": "alpha a"}}},
+		1,
+	)
+	require.NoError(t, err)
+	assert.False(t, validated)
+	assert.Nil(t, gepa.state.BestValidationCandidate)
+
+	validated, err = gepa.validateIfScheduled(
+		context.Background(),
+		newCandidateEvaluationTestProgram("alpha base"),
+		exactOutputMetric,
+		[]core.Example{{Outputs: map[string]interface{}{"output": "alpha a"}}},
+		2,
+	)
+	require.NoError(t, err)
+	assert.True(t, validated)
+	require.NotNil(t, gepa.state.BestValidationCandidate)
+}
+
+func TestSelectCandidateForUpdatePrefersValidationScore(t *testing.T) {
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			SelectionStrategy: "roulette",
+		},
+		state: NewGEPAState(),
+		rng:   rand.New(rand.NewSource(2)),
+	}
+
+	population := &Population{
+		Candidates: []*GEPACandidate{
+			{ID: "candidate-a", Fitness: 0.9},
+			{ID: "candidate-b", Fitness: 0.4},
+		},
+	}
+	gepa.state.SetCandidateValidationEvaluations(map[string]*gepaCandidateEvaluation{
+		"candidate-a": {AverageScore: 0.0},
+		"candidate-b": {AverageScore: 1.0},
+	})
+
+	selected := gepa.selectCandidateForUpdate(population)
+	require.NotNil(t, selected)
+	assert.Equal(t, "candidate-b", selected.ID)
+}
+
+func TestSelectCandidateForUpdateFallsBackWhenValidationCoverageIsPartial(t *testing.T) {
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			SelectionStrategy: "roulette",
+		},
+		state: NewGEPAState(),
+		rng:   rand.New(rand.NewSource(2)),
+	}
+
+	population := &Population{
+		Candidates: []*GEPACandidate{
+			{ID: "candidate-a", Fitness: 1.0},
+			{ID: "candidate-b", Fitness: 0.0},
+		},
+	}
+	gepa.state.SetCandidateValidationEvaluations(map[string]*gepaCandidateEvaluation{
+		"candidate-b": {AverageScore: 1.0},
+	})
+
+	selected := gepa.selectCandidateForUpdate(population)
+	require.NotNil(t, selected)
+	assert.Equal(t, "candidate-a", selected.ID)
+}
+
+func TestValidationAdjustedMultiObjectiveFitness(t *testing.T) {
+	base := &MultiObjectiveFitness{
+		SuccessRate:    0.2,
+		OutputQuality:  0.8,
+		Efficiency:     0.4,
+		Robustness:     0.6,
+		Generalization: 0.7,
+		Diversity:      0.3,
+		Innovation:     0.5,
+	}
+
+	withBase := validationAdjustedMultiObjectiveFitness(base, 0.9)
+	require.NotNil(t, withBase)
+	assert.Equal(t, 0.9, withBase.SuccessRate)
+	assert.Equal(t, base.OutputQuality, withBase.OutputQuality)
+	assert.Equal(t, base.Efficiency, withBase.Efficiency)
+	assert.Equal(t, base.Robustness, withBase.Robustness)
+
+	withoutBase := validationAdjustedMultiObjectiveFitness(nil, 0.7)
+	require.NotNil(t, withoutBase)
+	assert.Equal(t, 0.7, withoutBase.SuccessRate)
+	assert.Equal(t, 0.7, withoutBase.OutputQuality)
+	assert.Equal(t, 0.5, withoutBase.Efficiency)
+	assert.Equal(t, 0.5, withoutBase.Robustness)
 }
 
 func TestEvaluatePopulationSnapshotsBatchOnce(t *testing.T) {


### PR DESCRIPTION
## Summary
- add an internal train/validation split to core GEPA compile flow
- use validation-guided candidate selection and all-time best validation tracking without changing training minibatch acceptance
- reuse cached validation evaluations for unchanged candidates and cover the new validation paths with focused tests

## Verification
- go test -race ./pkg/optimizers -run 'TestEvaluateValidationPopulationHandlesMixedCachedAndUncachedCandidates' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- go test ./...
- golangci-lint run ./...