### PR TITLE
GEPA: add ancestor-aware merge proposals

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -4248,7 +4248,7 @@ func (g *GEPA) evolvePopulation(ctx context.Context) error {
 		return fmt.Errorf("no candidates available for proposal evolution")
 	}
 
-	nextCandidate := g.proposeNextGenerationCandidate(ctx, source, nextGeneration)
+	nextCandidate := g.proposeNextGenerationCandidate(ctx, currentPop, source, nextGeneration)
 	g.ensureCandidateMetrics(nextCandidate.ID)
 	g.syncCandidateUpdateState(ctx, source, nextCandidate)
 
@@ -4275,9 +4275,13 @@ func (g *GEPA) evolvePopulation(ctx context.Context) error {
 	return nil
 }
 
-func (g *GEPA) proposeNextGenerationCandidate(ctx context.Context, source *GEPACandidate, nextGeneration int) *GEPACandidate {
-	if source == nil {
+func (g *GEPA) proposeNextGenerationCandidate(ctx context.Context, population *Population, source *GEPACandidate, nextGeneration int) *GEPACandidate {
+	if population == nil || source == nil {
 		return nil
+	}
+
+	if merged := g.tryAncestorMergeProposal(ctx, population, source, nextGeneration); merged != nil {
+		return merged
 	}
 
 	focusedSource := g.prepareCandidateForComponentUpdate(source)

--- a/pkg/optimizers/gepa_acceptance_adapter.go
+++ b/pkg/optimizers/gepa_acceptance_adapter.go
@@ -22,7 +22,7 @@ func (g *GEPA) getLatestEvaluationAdapter() *gepaEvaluationAdapter {
 	return g.latestEvaluationAdapter
 }
 
-func (g *GEPA) acceptMutationProposal(ctx context.Context, baseline, proposed *GEPACandidate) *GEPACandidate {
+func (g *GEPA) acceptCandidateProposal(ctx context.Context, baseline, proposed *GEPACandidate) *GEPACandidate {
 	if baseline == nil || proposed == nil {
 		if proposed != nil {
 			return proposed
@@ -66,6 +66,10 @@ func (g *GEPA) acceptMutationProposal(ctx context.Context, baseline, proposed *G
 	}, proposed.Metadata)
 
 	return proposed
+}
+
+func (g *GEPA) acceptMutationProposal(ctx context.Context, baseline, proposed *GEPACandidate) *GEPACandidate {
+	return g.acceptCandidateProposal(ctx, baseline, proposed)
 }
 
 func (g *GEPA) cachedOrEvaluateCandidate(ctx context.Context, candidate *GEPACandidate, adapter *gepaEvaluationAdapter) *gepaCandidateEvaluation {

--- a/pkg/optimizers/gepa_merge_adapter.go
+++ b/pkg/optimizers/gepa_merge_adapter.go
@@ -1,0 +1,250 @@
+package optimizers
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+type gepaAncestorMergeChoice struct {
+	partner               *GEPACandidate
+	ancestor              *GEPACandidate
+	adoptedComponents     []string
+	conflictingComponents []string
+	coverage              int
+}
+
+func (g *GEPA) tryAncestorMergeProposal(ctx context.Context, population *Population, source *GEPACandidate, nextGeneration int) *GEPACandidate {
+	choice := g.selectAncestorMergePartner(population, source)
+	if choice == nil {
+		return nil
+	}
+
+	merged := g.buildAncestorMergedCandidate(source, choice, nextGeneration)
+	if merged == nil {
+		return nil
+	}
+
+	accepted := g.acceptCandidateProposal(ctx, source, merged)
+	if accepted == nil || accepted == source {
+		return nil
+	}
+	if accepted.Generation < nextGeneration {
+		accepted.Generation = nextGeneration
+	}
+
+	return accepted
+}
+
+func (g *GEPA) selectAncestorMergePartner(population *Population, source *GEPACandidate) *gepaAncestorMergeChoice {
+	if g == nil || g.state == nil || population == nil || source == nil {
+		return nil
+	}
+
+	_, coverage := g.state.ValidationFrontierSnapshot()
+	if len(coverage) == 0 || coverage[source.ID] == 0 {
+		return nil
+	}
+
+	var best *gepaAncestorMergeChoice
+	for _, candidate := range population.Candidates {
+		if candidate == nil || candidate.ID == source.ID || coverage[candidate.ID] == 0 {
+			continue
+		}
+
+		ancestor := g.findClosestCommonAncestor(source, candidate)
+		if ancestor == nil || ancestor.ID == source.ID || ancestor.ID == candidate.ID {
+			continue
+		}
+
+		adopted, conflicts := mergeableAncestorComponents(source, candidate, ancestor)
+		if len(adopted) == 0 {
+			continue
+		}
+
+		choice := &gepaAncestorMergeChoice{
+			partner:               candidate,
+			ancestor:              ancestor,
+			adoptedComponents:     adopted,
+			conflictingComponents: conflicts,
+			coverage:              coverage[candidate.ID],
+		}
+		if isBetterAncestorMergeChoice(choice, best) {
+			best = choice
+		}
+	}
+
+	return best
+}
+
+func isBetterAncestorMergeChoice(candidate, best *gepaAncestorMergeChoice) bool {
+	switch {
+	case candidate == nil:
+		return false
+	case best == nil:
+		return true
+	case len(candidate.adoptedComponents) != len(best.adoptedComponents):
+		return len(candidate.adoptedComponents) > len(best.adoptedComponents)
+	case candidate.coverage != best.coverage:
+		return candidate.coverage > best.coverage
+	case len(candidate.conflictingComponents) != len(best.conflictingComponents):
+		return len(candidate.conflictingComponents) < len(best.conflictingComponents)
+	case candidate.ancestor != nil && best.ancestor != nil && candidate.ancestor.ID != best.ancestor.ID:
+		return candidate.ancestor.ID < best.ancestor.ID
+	case candidate.partner != nil && best.partner != nil:
+		return candidate.partner.ID < best.partner.ID
+	default:
+		return false
+	}
+}
+
+func (g *GEPA) buildAncestorMergedCandidate(source *GEPACandidate, choice *gepaAncestorMergeChoice, nextGeneration int) *GEPACandidate {
+	if source == nil || choice == nil || choice.partner == nil || choice.ancestor == nil || len(choice.adoptedComponents) == 0 {
+		return nil
+	}
+
+	componentTexts := cloneCandidateComponentTexts(source)
+	if len(componentTexts) == 0 {
+		return nil
+	}
+
+	for _, moduleName := range choice.adoptedComponents {
+		componentTexts[moduleName] = candidateInstructionForModule(choice.partner, moduleName)
+	}
+
+	focusedModule := strings.TrimSpace(source.ModuleName)
+	if focusedModule == "" || !containsString(choice.adoptedComponents, focusedModule) {
+		focusedModule = choice.adoptedComponents[0]
+	}
+
+	return &GEPACandidate{
+		ID:             g.generateCandidateID(),
+		ModuleName:     focusedModule,
+		Instruction:    componentTexts[focusedModule],
+		ComponentTexts: componentTexts,
+		Generation:     nextGeneration,
+		Fitness:        source.Fitness,
+		ParentIDs:      []string{source.ID, choice.partner.ID},
+		CreatedAt:      time.Now(),
+		Metadata: mergeCandidateMetadata(map[string]interface{}{
+			"proposal_type":                "ancestor_merge",
+			"merge_partner_id":             choice.partner.ID,
+			"merge_common_ancestor_id":     choice.ancestor.ID,
+			"merge_adopted_components":     append([]string(nil), choice.adoptedComponents...),
+			"merge_conflicting_components": append([]string(nil), choice.conflictingComponents...),
+		}, source.Metadata, choice.partner.Metadata),
+	}
+}
+
+func mergeableAncestorComponents(source, partner, ancestor *GEPACandidate) ([]string, []string) {
+	moduleNames := candidateUnionComponentNames(source, partner, ancestor)
+	if len(moduleNames) == 0 {
+		return nil, nil
+	}
+
+	adopted := make([]string, 0, len(moduleNames))
+	conflicts := make([]string, 0)
+	for _, moduleName := range moduleNames {
+		ancestorInstruction := candidateInstructionForModule(ancestor, moduleName)
+		sourceInstruction := candidateInstructionForModule(source, moduleName)
+		partnerInstruction := candidateInstructionForModule(partner, moduleName)
+
+		sourceChanged := sourceInstruction != ancestorInstruction
+		partnerChanged := partnerInstruction != ancestorInstruction
+
+		switch {
+		case !sourceChanged && partnerChanged:
+			adopted = append(adopted, moduleName)
+		case sourceChanged && partnerChanged && sourceInstruction != partnerInstruction:
+			conflicts = append(conflicts, moduleName)
+		}
+	}
+
+	return adopted, conflicts
+}
+
+func candidateUnionComponentNames(candidates ...*GEPACandidate) []string {
+	componentTexts := make(map[string]string)
+	for _, candidate := range candidates {
+		for moduleName := range cloneCandidateComponentTexts(candidate) {
+			componentTexts[moduleName] = ""
+		}
+	}
+	return componentModuleNames(componentTexts)
+}
+
+func (g *GEPA) findClosestCommonAncestor(left, right *GEPACandidate) *GEPACandidate {
+	if g == nil || left == nil || right == nil {
+		return nil
+	}
+
+	leftDepths := g.candidateAncestorDepths(left)
+	rightDepths := g.candidateAncestorDepths(right)
+
+	bestDepth := -1
+	var best *GEPACandidate
+	for candidateID, leftDepth := range leftDepths {
+		rightDepth, exists := rightDepths[candidateID]
+		if !exists {
+			continue
+		}
+
+		ancestor := g.findCandidateInHistory(candidateID)
+		if ancestor == nil {
+			continue
+		}
+
+		totalDepth := leftDepth + rightDepth
+		if best == nil || totalDepth < bestDepth || (totalDepth == bestDepth && ancestor.ID < best.ID) {
+			best = ancestor
+			bestDepth = totalDepth
+		}
+	}
+
+	return best
+}
+
+func (g *GEPA) candidateAncestorDepths(candidate *GEPACandidate) map[string]int {
+	if g == nil || candidate == nil {
+		return nil
+	}
+
+	type queuedAncestor struct {
+		candidate *GEPACandidate
+		depth     int
+	}
+
+	depths := make(map[string]int)
+	queue := []queuedAncestor{{candidate: candidate, depth: 0}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		if current.candidate == nil || strings.TrimSpace(current.candidate.ID) == "" {
+			continue
+		}
+		if existingDepth, exists := depths[current.candidate.ID]; exists && existingDepth <= current.depth {
+			continue
+		}
+		depths[current.candidate.ID] = current.depth
+
+		for _, parentID := range current.candidate.ParentIDs {
+			parent := g.findCandidateInHistory(parentID)
+			if parent == nil {
+				continue
+			}
+			queue = append(queue, queuedAncestor{candidate: parent, depth: current.depth + 1})
+		}
+	}
+
+	return depths
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -2466,6 +2466,177 @@ func TestEvolvePopulationUsesCandidateCentricProposalLoop(t *testing.T) {
 	mockLLM.AssertExpectations(t)
 }
 
+func TestFindClosestCommonAncestorPrefersNearestSharedAncestor(t *testing.T) {
+	gepa := &GEPA{state: NewGEPAState()}
+
+	root := &GEPACandidate{
+		ID:             "root",
+		ComponentTexts: map[string]string{"alpha": "alpha base", "beta": "beta base"},
+	}
+	ancestor := &GEPACandidate{
+		ID:             "ancestor",
+		ComponentTexts: map[string]string{"alpha": "alpha base", "beta": "beta base"},
+		ParentIDs:      []string{"root"},
+	}
+	left := &GEPACandidate{
+		ID:             "left",
+		ComponentTexts: map[string]string{"alpha": "alpha tuned", "beta": "beta base"},
+		ParentIDs:      []string{"ancestor"},
+	}
+	right := &GEPACandidate{
+		ID:             "right",
+		ComponentTexts: map[string]string{"alpha": "alpha base", "beta": "beta tuned"},
+		ParentIDs:      []string{"ancestor"},
+	}
+
+	gepa.state.PopulationHistory = []*Population{
+		{Generation: 0, Candidates: []*GEPACandidate{root, ancestor}},
+		{Generation: 1, Candidates: []*GEPACandidate{left, right}},
+	}
+
+	commonAncestor := gepa.findClosestCommonAncestor(left, right)
+	require.NotNil(t, commonAncestor)
+	assert.Equal(t, "ancestor", commonAncestor.ID)
+}
+
+func TestBuildAncestorMergedCandidateAdoptsPartnerOnlyComponents(t *testing.T) {
+	gepa := &GEPA{
+		state: NewGEPAState(),
+		rng:   rand.New(rand.NewSource(7)),
+	}
+
+	source := &GEPACandidate{
+		ID:          "source",
+		ModuleName:  "alpha",
+		Instruction: "alpha tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha tuned",
+			"beta":  "beta base",
+		},
+		Fitness: 0.4,
+	}
+	partner := &GEPACandidate{
+		ID:          "partner",
+		ModuleName:  "beta",
+		Instruction: "beta tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta tuned",
+		},
+	}
+	ancestor := &GEPACandidate{
+		ID: "ancestor",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta base",
+		},
+	}
+
+	merged := gepa.buildAncestorMergedCandidate(source, &gepaAncestorMergeChoice{
+		partner:           partner,
+		ancestor:          ancestor,
+		adoptedComponents: []string{"beta"},
+		coverage:          1,
+	}, 3)
+	require.NotNil(t, merged)
+
+	assert.Equal(t, 3, merged.Generation)
+	assert.Equal(t, "beta", merged.ModuleName)
+	assert.Equal(t, "beta tuned", merged.Instruction)
+	assert.Equal(t, map[string]string{
+		"alpha": "alpha tuned",
+		"beta":  "beta tuned",
+	}, merged.ComponentTexts)
+	assert.Equal(t, []string{"source", "partner"}, merged.ParentIDs)
+	assert.Equal(t, "ancestor_merge", merged.Metadata["proposal_type"])
+	assert.Equal(t, "partner", merged.Metadata["merge_partner_id"])
+	assert.Equal(t, "ancestor", merged.Metadata["merge_common_ancestor_id"])
+}
+
+func TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving(t *testing.T) {
+	generationLLM := &countingLLM{}
+	gepa := &GEPA{
+		config:        DefaultGEPAConfig(),
+		state:         NewGEPAState(),
+		generationLLM: generationLLM,
+		rng:           rand.New(rand.NewSource(9)),
+	}
+
+	root := &GEPACandidate{
+		ID:          "root",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta base",
+		},
+		Fitness: 0.0,
+	}
+	source := &GEPACandidate{
+		ID:          "source",
+		ModuleName:  "alpha",
+		Instruction: "alpha tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha tuned",
+			"beta":  "beta base",
+		},
+		ParentIDs: []string{"root"},
+		Fitness:   0.0,
+	}
+	partner := &GEPACandidate{
+		ID:          "partner",
+		ModuleName:  "beta",
+		Instruction: "beta tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta tuned",
+		},
+		ParentIDs: []string{"root"},
+		Fitness:   0.0,
+	}
+	current := &Population{
+		Generation: 1,
+		Candidates: []*GEPACandidate{source, partner},
+	}
+	gepa.state.PopulationHistory = []*Population{
+		{Generation: 0, Candidates: []*GEPACandidate{root}},
+		current,
+	}
+	gepa.state.SetValidationFrontier(nil, map[string]int{
+		"source":  2,
+		"partner": 1,
+	})
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+	})
+	adapter := gepa.newEvaluationAdapter(
+		newTwoModuleCandidateEvaluationTestProgram("alpha base", "beta base"),
+		dataset,
+		exactOutputMetric,
+	)
+	gepa.setLatestEvaluationAdapter(adapter)
+
+	proposed := gepa.proposeNextGenerationCandidate(context.Background(), current, source, 2)
+	require.NotNil(t, proposed)
+
+	assert.Equal(t, 0, generationLLM.generateCalls)
+	assert.Equal(t, 2, proposed.Generation)
+	assert.Equal(t, 1.0, proposed.Fitness)
+	assert.Equal(t, "beta", proposed.ModuleName)
+	assert.Equal(t, "beta tuned", proposed.Instruction)
+	assert.Equal(t, []string{"source", "partner"}, proposed.ParentIDs)
+	assert.Equal(t, map[string]string{
+		"alpha": "alpha tuned",
+		"beta":  "beta tuned",
+	}, proposed.ComponentTexts)
+	assert.Equal(t, "ancestor_merge", proposed.Metadata["proposal_type"])
+
+	evaluation := gepa.state.GetCandidateEvaluation(proposed.ID)
+	require.NotNil(t, evaluation)
+	assert.Equal(t, 1.0, evaluation.AverageScore)
+}
+
 func TestEvolvePopulationCarriesForwardCandidatesWithoutSelectedParents(t *testing.T) {
 	gepa := &GEPA{
 		config: &GEPAConfig{


### PR DESCRIPTION
## Summary
- add deterministic ancestor-aware whole-program merge proposals based on shared lineage and validation-frontier contributors
- route merged candidates through the same minibatch acceptance gate used for mutation proposals
- expand optimizer coverage for common-ancestor lookup, merged candidate construction, and merge-driven proposal acceptance

## Verification
- go test ./pkg/optimizers -run 'TestFindClosestCommonAncestorPrefersNearestSharedAncestor|TestBuildAncestorMergedCandidateAdoptsPartnerOnlyComponents|TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving|TestEvolvePopulationUsesCandidateCentricProposalLoop|TestSelectCandidateForUpdatePrefersValidationFrontierContributor' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- go test ./...
- golangci-lint run ./...