### PR TITLE
GEPA: add component selection parity modes

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -44,6 +44,14 @@ const (
 	objectiveInnovation     = "innovation"
 )
 
+const (
+	componentSelectionRandom     = "random"
+	componentSelectionRoundRobin = "round_robin"
+	componentSelectionAll        = "all"
+)
+
+const gepaComponentSelectionCursorMetadataKey = "component_selection_cursor"
+
 var multiObjectiveNames = []string{
 	objectiveSuccess,
 	objectiveQuality,
@@ -82,8 +90,9 @@ type GEPAConfig struct {
 	SelfCritiqueTemp float64 `json:"self_critique_temp"`   // Default: 0.7
 
 	// Selection parameters
-	TournamentSize    int    `json:"tournament_size"`    // Default: 3
-	SelectionStrategy string `json:"selection_strategy"` // Default: "tournament" | "roulette" | "pareto" | "adaptive_pareto"
+	TournamentSize     int    `json:"tournament_size"`     // Default: 3
+	SelectionStrategy  string `json:"selection_strategy"`  // Default: "tournament" | "roulette" | "pareto" | "adaptive_pareto"
+	ComponentSelection string `json:"component_selection"` // Default: "round_robin" | "random" | "all"
 
 	// Convergence parameters
 	ConvergenceThreshold float64 `json:"convergence_threshold"` // Default: 0.01
@@ -115,6 +124,7 @@ func DefaultGEPAConfig() *GEPAConfig {
 		SelfCritiqueTemp:     0.7,
 		TournamentSize:       3,
 		SelectionStrategy:    "adaptive_pareto", // Use adaptive Pareto as default for sophisticated multi-objective optimization
+		ComponentSelection:   componentSelectionRoundRobin,
 		ConvergenceThreshold: 0.01,
 		StagnationLimit:      3,
 		EvaluationBatchSize:  5,
@@ -2898,6 +2908,14 @@ func NewGEPA(config *GEPAConfig) (*GEPA, error) {
 	if config.SelectionStrategy == "" {
 		config.SelectionStrategy = defaults.SelectionStrategy
 	}
+	switch config.ComponentSelection {
+	case "", componentSelectionRandom, componentSelectionRoundRobin, componentSelectionAll:
+		if config.ComponentSelection == "" {
+			config.ComponentSelection = defaults.ComponentSelection
+		}
+	default:
+		config.ComponentSelection = defaults.ComponentSelection
+	}
 
 	// Initialize LLMs
 	generationLLM := core.GetDefaultLLM()
@@ -4280,52 +4298,183 @@ func (g *GEPA) proposeNextGenerationCandidate(ctx context.Context, population *P
 		return nil
 	}
 
+	componentSelection := g.selectComponentsForUpdate(source)
+
 	if merged := g.tryAncestorMergeProposal(ctx, population, source, nextGeneration); merged != nil {
-		return merged
+		return g.applyComponentSelectionState(merged, componentSelection.nextCursor)
 	}
 
-	focusedSource := g.prepareCandidateForComponentUpdate(source)
-	proposed := g.mutate(ctx, focusedSource)
-	if proposed == nil || proposed == source || proposed == focusedSource {
+	var proposed *GEPACandidate
+	switch len(componentSelection.modules) {
+	case 0:
+		proposed = nil
+	case 1:
+		focusedSource := g.prepareCandidateForComponentUpdate(source, componentSelection.modules[0])
+		proposed = g.mutate(ctx, focusedSource)
+		if proposed == focusedSource {
+			proposed = source
+		}
+	default:
+		proposed = g.proposeMultiComponentCandidate(ctx, source, componentSelection.modules, nextGeneration)
+	}
+
+	if proposed == nil || proposed == source {
 		carried := g.copyCandidate(source)
 		carried.Generation = nextGeneration
-		return carried
+		return g.applyComponentSelectionState(carried, componentSelection.nextCursor)
 	}
 
 	if proposed.Generation < nextGeneration {
 		proposed.Generation = nextGeneration
 	}
 
-	return proposed
+	return g.applyComponentSelectionState(proposed, componentSelection.nextCursor)
 }
 
-func (g *GEPA) prepareCandidateForComponentUpdate(source *GEPACandidate) *GEPACandidate {
+func (g *GEPA) prepareCandidateForComponentUpdate(source *GEPACandidate, moduleName string) *GEPACandidate {
 	if source == nil {
 		return nil
 	}
 
-	moduleName := g.selectComponentForUpdate(source)
 	focused := g.copyCandidate(source)
 	focused.ModuleName = moduleName
 	focused.Instruction = candidateInstructionForModule(source, moduleName)
 	return focused
 }
 
-func (g *GEPA) selectComponentForUpdate(candidate *GEPACandidate) string {
+type gepaComponentSelectionPlan struct {
+	modules    []string
+	nextCursor int
+}
+
+func (g *GEPA) selectComponentsForUpdate(candidate *GEPACandidate) gepaComponentSelectionPlan {
 	if candidate == nil {
-		return ""
+		return gepaComponentSelectionPlan{}
 	}
 
 	moduleNames := componentModuleNames(cloneCandidateComponentTexts(candidate))
 	if len(moduleNames) == 0 {
-		return strings.TrimSpace(candidate.ModuleName)
+		moduleName := strings.TrimSpace(candidate.ModuleName)
+		if moduleName == "" {
+			return gepaComponentSelectionPlan{}
+		}
+		return gepaComponentSelectionPlan{
+			modules:    []string{moduleName},
+			nextCursor: 0,
+		}
 	}
 
-	// The current whole-program refactor keeps component focus selection simple:
-	// choose one module uniformly at random from the candidate state. This keeps
-	// the iterative update path lightweight for now; round-robin or "update all"
-	// strategies can layer on top of the same whole-program candidate model later.
-	return moduleNames[g.rng.Intn(len(moduleNames))]
+	switch g.config.ComponentSelection {
+	case componentSelectionAll:
+		return gepaComponentSelectionPlan{
+			modules:    moduleNames,
+			nextCursor: componentSelectionCursor(candidate),
+		}
+	case componentSelectionRandom:
+		return gepaComponentSelectionPlan{
+			modules:    []string{moduleNames[g.rng.Intn(len(moduleNames))]},
+			nextCursor: componentSelectionCursor(candidate),
+		}
+	default:
+		cursor := componentSelectionCursor(candidate)
+		index := cursor % len(moduleNames)
+		return gepaComponentSelectionPlan{
+			modules:    []string{moduleNames[index]},
+			nextCursor: (index + 1) % len(moduleNames),
+		}
+	}
+}
+
+func componentSelectionCursor(candidate *GEPACandidate) int {
+	if candidate == nil || candidate.Metadata == nil {
+		return 0
+	}
+
+	switch value := candidate.Metadata[gepaComponentSelectionCursorMetadataKey].(type) {
+	case int:
+		if value >= 0 {
+			return value
+		}
+	case float64:
+		if value >= 0 {
+			return int(value)
+		}
+	}
+
+	return 0
+}
+
+func (g *GEPA) applyComponentSelectionState(candidate *GEPACandidate, nextCursor int) *GEPACandidate {
+	if candidate == nil {
+		return nil
+	}
+	if candidate.Metadata == nil {
+		candidate.Metadata = make(map[string]interface{})
+	}
+	candidate.Metadata[gepaComponentSelectionCursorMetadataKey] = nextCursor
+	return candidate
+}
+
+func (g *GEPA) proposeMultiComponentCandidate(ctx context.Context, source *GEPACandidate, modules []string, nextGeneration int) *GEPACandidate {
+	if source == nil || len(modules) == 0 {
+		return nil
+	}
+
+	working := g.copyCandidate(source)
+	componentTexts := cloneCandidateComponentTexts(source)
+	if len(componentTexts) == 0 {
+		return nil
+	}
+
+	appliedModules := make([]string, 0, len(modules))
+	metadataSources := []map[string]interface{}{source.Metadata}
+	focusedModule := strings.TrimSpace(source.ModuleName)
+
+	for _, moduleName := range modules {
+		focused := g.copyCandidate(working)
+		focused.ComponentTexts = cloneComponentTexts(componentTexts)
+		focused.ModuleName = moduleName
+		focused.Instruction = candidateInstructionForModule(working, moduleName)
+
+		proposed := g.proposeMutationCandidate(ctx, focused)
+		if proposed == nil || proposed == focused {
+			continue
+		}
+
+		componentTexts = cloneCandidateComponentTexts(proposed)
+		working.ComponentTexts = cloneComponentTexts(componentTexts)
+		working.ModuleName = moduleName
+		working.Instruction = candidateInstructionForModule(proposed, moduleName)
+		metadataSources = append(metadataSources, proposed.Metadata)
+		appliedModules = append(appliedModules, moduleName)
+		focusedModule = moduleName
+	}
+
+	if len(appliedModules) == 0 {
+		return nil
+	}
+
+	proposed := &GEPACandidate{
+		ID:             g.generateCandidateID(),
+		ModuleName:     focusedModule,
+		Instruction:    candidateInstructionForModule(working, focusedModule),
+		ComponentTexts: cloneComponentTexts(componentTexts),
+		Generation:     nextGeneration,
+		Fitness:        source.Fitness,
+		ParentIDs:      []string{source.ID},
+		CreatedAt:      time.Now(),
+		Metadata: mergeCandidateMetadata(map[string]interface{}{
+			"proposal_type":        "multi_component_update",
+			"updated_components":   append([]string(nil), appliedModules...),
+			"component_update_all": true,
+		}, metadataSources...),
+	}
+
+	accepted := g.acceptCandidateProposal(ctx, source, proposed)
+	if accepted == source {
+		return nil
+	}
+	return accepted
 }
 
 // selectCandidates returns candidates sampled according to the configured
@@ -4806,23 +4955,24 @@ func (g *GEPA) selectParetoElite(candidates []*GEPACandidate, fitnessMap map[str
 
 // mutate applies mutation to a candidate.
 func (g *GEPA) mutate(ctx context.Context, candidate *GEPACandidate) *GEPACandidate {
-	if g.rng.Float64() > g.config.MutationRate {
-		return candidate // No mutation
-	}
-
-	if proposed := g.reflectionGuidedMutation(ctx, candidate); proposed != nil {
-		if proposed == candidate {
-			return candidate
-		}
-		return g.acceptMutationProposal(ctx, candidate, proposed)
-	}
-
-	proposed := g.semanticMutation(ctx, candidate)
+	proposed := g.proposeMutationCandidate(ctx, candidate)
 	if proposed == candidate {
 		return candidate
 	}
 
 	return g.acceptMutationProposal(ctx, candidate, proposed)
+}
+
+func (g *GEPA) proposeMutationCandidate(ctx context.Context, candidate *GEPACandidate) *GEPACandidate {
+	if g.rng.Float64() > g.config.MutationRate {
+		return candidate // No mutation
+	}
+
+	if proposed := g.reflectionGuidedMutation(ctx, candidate); proposed != nil {
+		return proposed
+	}
+
+	return g.semanticMutation(ctx, candidate)
 }
 
 // semanticMutation performs LLM-based semantic mutation.

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -305,6 +305,7 @@ func TestDefaultGEPAConfig(t *testing.T) {
 	assert.Equal(t, 0.1, config.ElitismRate)
 	assert.Equal(t, 2, config.ReflectionFreq)
 	assert.Equal(t, 3, config.TournamentSize)
+	assert.Equal(t, componentSelectionRoundRobin, config.ComponentSelection)
 }
 
 func TestDefaultMultiObjectiveWeights(t *testing.T) {
@@ -530,6 +531,57 @@ func TestCandidateInstructionForModule(t *testing.T) {
 		Instruction: "alpha inline",
 	}
 	assert.Equal(t, "alpha inline", candidateInstructionForModule(inlineOnly, "alpha"))
+}
+
+func TestSelectComponentsForUpdateRoundRobinCyclesModules(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ComponentSelection = componentSelectionRoundRobin
+
+	candidate := &GEPACandidate{
+		ID:          "candidate",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta base",
+		},
+	}
+
+	first := gepa.selectComponentsForUpdate(candidate)
+	require.Equal(t, []string{"alpha"}, first.modules)
+	assert.Equal(t, 1, first.nextCursor)
+
+	candidate.Metadata = map[string]interface{}{gepaComponentSelectionCursorMetadataKey: first.nextCursor}
+	second := gepa.selectComponentsForUpdate(candidate)
+	require.Equal(t, []string{"beta"}, second.modules)
+	assert.Equal(t, 0, second.nextCursor)
+}
+
+func TestSelectComponentsForUpdateAllReturnsAllModules(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(1)),
+	}
+	gepa.config.ComponentSelection = componentSelectionAll
+
+	candidate := &GEPACandidate{
+		ID:          "candidate",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta base",
+		},
+	}
+
+	selection := gepa.selectComponentsForUpdate(candidate)
+	assert.Equal(t, []string{"alpha", "beta"}, selection.modules)
+	assert.Equal(t, 0, selection.nextCursor)
 }
 
 func TestApplyBestCandidateUsesWholeProgramState(t *testing.T) {
@@ -2464,6 +2516,106 @@ func TestEvolvePopulationUsesCandidateCentricProposalLoop(t *testing.T) {
 	assert.Equal(t, 1, unchangedCount)
 
 	mockLLM.AssertExpectations(t)
+}
+
+func TestProposeNextGenerationCandidateAllSelectionUpdatesBothComponents(t *testing.T) {
+	mockLLM := &testutil.MockLLM{}
+	mockLLM.On("Generate", mock.Anything, mock.MatchedBy(func(prompt string) bool {
+		return strings.Contains(prompt, `Original: "alpha base"`)
+	}), mock.Anything).Return(&core.LLMResponse{
+		Content: "alpha improved",
+	}, nil).Once()
+	mockLLM.On("Generate", mock.Anything, mock.MatchedBy(func(prompt string) bool {
+		return strings.Contains(prompt, `Original: "beta base"`)
+	}), mock.Anything).Return(&core.LLMResponse{
+		Content: "beta improved",
+	}, nil).Once()
+
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			PopulationSize:      1,
+			MutationRate:        1.0,
+			SelectionStrategy:   "tournament",
+			TournamentSize:      1,
+			ComponentSelection:  componentSelectionAll,
+			ConcurrencyLevel:    1,
+			EvaluationBatchSize: 1,
+		},
+		state:         NewGEPAState(),
+		generationLLM: mockLLM,
+		rng:           rand.New(rand.NewSource(5)),
+	}
+
+	dataset := newCountingDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "alpha improved|beta improved"}},
+	})
+	adapter := gepa.newEvaluationAdapter(
+		newTwoModuleCandidateEvaluationTestProgram("alpha base", "beta base"),
+		dataset,
+		exactOutputMetric,
+	)
+	gepa.setLatestEvaluationAdapter(adapter)
+
+	source := &GEPACandidate{
+		ID:          "candidate",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta base",
+		},
+		Fitness: 0.0,
+	}
+	population := &Population{
+		Generation: 1,
+		Candidates: []*GEPACandidate{source},
+	}
+
+	proposed := gepa.proposeNextGenerationCandidate(context.Background(), population, source, 2)
+	require.NotNil(t, proposed)
+	assert.Equal(t, 2, proposed.Generation)
+	assert.Equal(t, 1.0, proposed.Fitness)
+	assert.Equal(t, "beta", proposed.ModuleName)
+	assert.Equal(t, "beta improved", proposed.Instruction)
+	assert.Equal(t, map[string]string{
+		"alpha": "alpha improved",
+		"beta":  "beta improved",
+	}, proposed.ComponentTexts)
+	assert.Equal(t, "multi_component_update", proposed.Metadata["proposal_type"])
+	assert.Equal(t, true, proposed.Metadata["component_update_all"])
+	assert.Equal(t, 0, proposed.Metadata[gepaComponentSelectionCursorMetadataKey])
+
+	mockLLM.AssertExpectations(t)
+}
+
+func TestProposeNextGenerationCandidateCarriesRoundRobinCursorForward(t *testing.T) {
+	gepa := &GEPA{
+		config: &GEPAConfig{
+			MutationRate:       0.0,
+			ComponentSelection: componentSelectionRoundRobin,
+		},
+		state: NewGEPAState(),
+		rng:   rand.New(rand.NewSource(1)),
+	}
+
+	source := &GEPACandidate{
+		ID:          "candidate",
+		ModuleName:  "alpha",
+		Instruction: "alpha base",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta base",
+		},
+		Metadata: map[string]interface{}{
+			gepaComponentSelectionCursorMetadataKey: 0,
+		},
+	}
+	population := &Population{Generation: 1, Candidates: []*GEPACandidate{source}}
+
+	proposed := gepa.proposeNextGenerationCandidate(context.Background(), population, source, 2)
+	require.NotNil(t, proposed)
+	assert.Equal(t, source.ID, proposed.ID)
+	assert.Equal(t, 1, proposed.Metadata[gepaComponentSelectionCursorMetadataKey])
 }
 
 func TestFindClosestCommonAncestorPrefersNearestSharedAncestor(t *testing.T) {


### PR DESCRIPTION
## Summary
- add explicit GEPA component-selection modes with `round_robin` as the new default plus `random` and `all`
- persist round-robin cursor state across iterative updates and allow `all` mode to update multiple components in one GEPA step
- add deterministic optimizer tests modeled on current DSPy GEPA component-selection behavior

## Verification
- go test ./pkg/optimizers -run 'TestDefaultGEPAConfig|TestSelectComponentsForUpdateRoundRobinCyclesModules|TestSelectComponentsForUpdateAllReturnsAllModules|TestProposeNextGenerationCandidateAllSelectionUpdatesBothComponents|TestProposeNextGenerationCandidateCarriesRoundRobinCursorForward|TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- golangci-lint run ./...

## Notes
- `go test ./...` still hits the existing unrelated failure in `pkg/llms/oauth` (`TestOpenBrowser`).
