### PR TITLE
GEPA: prune dominated validation frontier ties

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -331,14 +331,16 @@ type CandidateMetrics struct {
 	Metadata         map[string]interface{} `json:"metadata"`
 }
 
-// gepaValidationFrontierEntry records the current validation-frontier winner
-// for one validation example. This lets GEPA keep example-level coverage
-// instead of collapsing validation to a single scalar score per candidate.
+// gepaValidationFrontierEntry records the tied-best validation-frontier
+// programs for one validation example. CandidateID remains as a canonical
+// representative for compatibility, while CandidateIDs preserves the full
+// pruned tied-best set used for coverage-based selection.
 type gepaValidationFrontierEntry struct {
-	CaseIndex   int          `json:"case_index"`
-	CandidateID string       `json:"candidate_id"`
-	Score       float64      `json:"score"`
-	Example     core.Example `json:"example"`
+	CaseIndex    int          `json:"case_index"`
+	CandidateID  string       `json:"candidate_id,omitempty"`
+	CandidateIDs []string     `json:"candidate_ids,omitempty"`
+	Score        float64      `json:"score"`
+	Example      core.Example `json:"example"`
 }
 
 // GEPAState tracks the complete state of GEPA optimization.
@@ -607,10 +609,11 @@ func cloneValidationFrontierEntry(entry *gepaValidationFrontierEntry) *gepaValid
 	}
 
 	return &gepaValidationFrontierEntry{
-		CaseIndex:   entry.CaseIndex,
-		CandidateID: entry.CandidateID,
-		Score:       entry.Score,
-		Example:     cloneEvaluationExample(entry.Example),
+		CaseIndex:    entry.CaseIndex,
+		CandidateID:  entry.CandidateID,
+		CandidateIDs: append([]string(nil), entry.CandidateIDs...),
+		Score:        entry.Score,
+		Example:      cloneEvaluationExample(entry.Example),
 	}
 }
 
@@ -3251,37 +3254,177 @@ func buildValidationFrontier(evaluations map[string]*gepaCandidateEvaluation) (m
 	}
 
 	frontier := make(map[int]*gepaValidationFrontierEntry)
-	coverage := make(map[string]int)
+	candidateIDs := make([]string, 0, len(evaluations))
+	candidateScores := make(map[string]float64, len(evaluations))
+	for candidateID := range evaluations {
+		candidateIDs = append(candidateIDs, candidateID)
+	}
+	sort.Strings(candidateIDs)
 
-	for candidateID, evaluation := range evaluations {
+	for _, candidateID := range candidateIDs {
+		evaluation := evaluations[candidateID]
 		if evaluation == nil {
 			continue
 		}
+		candidateScores[candidateID] = evaluation.AverageScore
 
 		for caseIndex, evalCase := range evaluation.Cases {
 			score := evalCase.Score
 			current := frontier[caseIndex]
-			if current != nil && (score < current.Score || (score == current.Score && candidateID >= current.CandidateID)) {
-				continue
-			}
-
-			frontier[caseIndex] = &gepaValidationFrontierEntry{
-				CaseIndex:   caseIndex,
-				CandidateID: candidateID,
-				Score:       score,
-				Example:     cloneEvaluationExample(evalCase.Example),
+			switch {
+			case current == nil || score > current.Score:
+				frontier[caseIndex] = &gepaValidationFrontierEntry{
+					CaseIndex:    caseIndex,
+					CandidateID:  candidateID,
+					CandidateIDs: []string{candidateID},
+					Score:        score,
+					Example:      cloneEvaluationExample(evalCase.Example),
+				}
+			case score == current.Score:
+				current.CandidateIDs = append(current.CandidateIDs, candidateID)
+				if current.CandidateID == "" || candidateID < current.CandidateID {
+					current.CandidateID = candidateID
+				}
 			}
 		}
 	}
 
+	prunedFrontier := pruneValidationFrontier(frontier, candidateScores)
+	coverage := make(map[string]int)
+	for _, entry := range prunedFrontier {
+		if entry == nil {
+			continue
+		}
+		for _, candidateID := range entry.CandidateIDs {
+			coverage[candidateID]++
+		}
+	}
+
+	return prunedFrontier, coverage
+}
+
+func pruneValidationFrontier(frontier map[int]*gepaValidationFrontierEntry, candidateScores map[string]float64) map[int]*gepaValidationFrontierEntry {
+	if len(frontier) == 0 {
+		return nil
+	}
+
+	orderedCandidateIDs := validationFrontierCandidateIDs(frontier)
+	if len(orderedCandidateIDs) <= 1 {
+		return frontier
+	}
+
+	sort.SliceStable(orderedCandidateIDs, func(i, j int) bool {
+		left := orderedCandidateIDs[i]
+		right := orderedCandidateIDs[j]
+		leftScore := candidateScores[left]
+		rightScore := candidateScores[right]
+		if leftScore == rightScore {
+			return left < right
+		}
+		return leftScore < rightScore
+	})
+
+	remaining := make(map[string]struct{}, len(orderedCandidateIDs))
+	for _, candidateID := range orderedCandidateIDs {
+		remaining[candidateID] = struct{}{}
+	}
+
+	for _, candidateID := range orderedCandidateIDs {
+		if _, ok := remaining[candidateID]; !ok {
+			continue
+		}
+		if isValidationFrontierCandidateDominated(candidateID, remaining, frontier) {
+			delete(remaining, candidateID)
+		}
+	}
+
+	prunedFrontier := make(map[int]*gepaValidationFrontierEntry, len(frontier))
+	for caseIndex, entry := range frontier {
+		if entry == nil {
+			continue
+		}
+
+		candidateIDs := make([]string, 0, len(entry.CandidateIDs))
+		for _, candidateID := range entry.CandidateIDs {
+			if _, ok := remaining[candidateID]; ok {
+				candidateIDs = append(candidateIDs, candidateID)
+			}
+		}
+		if len(candidateIDs) == 0 {
+			continue
+		}
+
+		prunedFrontier[caseIndex] = &gepaValidationFrontierEntry{
+			CaseIndex:    entry.CaseIndex,
+			CandidateID:  candidateIDs[0],
+			CandidateIDs: candidateIDs,
+			Score:        entry.Score,
+			Example:      cloneEvaluationExample(entry.Example),
+		}
+	}
+
+	return prunedFrontier
+}
+
+func validationFrontierCandidateIDs(frontier map[int]*gepaValidationFrontierEntry) []string {
+	seen := make(map[string]struct{})
+	candidateIDs := make([]string, 0)
 	for _, entry := range frontier {
 		if entry == nil {
 			continue
 		}
-		coverage[entry.CandidateID]++
+		for _, candidateID := range entry.CandidateIDs {
+			if candidateID == "" {
+				continue
+			}
+			if _, ok := seen[candidateID]; ok {
+				continue
+			}
+			seen[candidateID] = struct{}{}
+			candidateIDs = append(candidateIDs, candidateID)
+		}
+	}
+	return candidateIDs
+}
+
+func isValidationFrontierCandidateDominated(candidateID string, remaining map[string]struct{}, frontier map[int]*gepaValidationFrontierEntry) bool {
+	if candidateID == "" || len(remaining) <= 1 {
+		return false
 	}
 
-	return frontier, coverage
+	for _, entry := range frontier {
+		if entry == nil || !validationFrontierEntryContainsCandidate(entry, candidateID) {
+			continue
+		}
+
+		coveredByOther := false
+		for _, otherCandidateID := range entry.CandidateIDs {
+			if otherCandidateID == candidateID {
+				continue
+			}
+			if _, ok := remaining[otherCandidateID]; ok {
+				coveredByOther = true
+				break
+			}
+		}
+		if !coveredByOther {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validationFrontierEntryContainsCandidate(entry *gepaValidationFrontierEntry, candidateID string) bool {
+	if entry == nil || candidateID == "" {
+		return false
+	}
+	for _, currentCandidateID := range entry.CandidateIDs {
+		if currentCandidateID == candidateID {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *GEPA) reflectIfScheduled(ctx context.Context, generation int) error {

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -1037,27 +1037,72 @@ func TestBuildValidationFrontierTracksCoverage(t *testing.T) {
 	evaluations := map[string]*gepaCandidateEvaluation{
 		"candidate-a": {
 			Cases: []gepaEvaluationCase{
-				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-0"}}, Score: 0.4},
-				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-1"}}, Score: 0.4},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-0"}}, Score: 1.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-1"}}, Score: 0.0},
 				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-2"}}, Score: 0.0},
 			},
+			AverageScore: 1.0 / 3.0,
 		},
 		"candidate-b": {
 			Cases: []gepaEvaluationCase{
-				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-0"}}, Score: 0.3},
-				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-1"}}, Score: 0.3},
-				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-2"}}, Score: 0.9},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-0"}}, Score: 1.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-1"}}, Score: 1.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-2"}}, Score: 0.0},
 			},
+			AverageScore: 2.0 / 3.0,
+		},
+		"candidate-c": {
+			Cases: []gepaEvaluationCase{
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "c-0"}}, Score: 0.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "c-1"}}, Score: 1.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "c-2"}}, Score: 1.0},
+			},
+			AverageScore: 2.0 / 3.0,
 		},
 	}
 
 	frontier, coverage := buildValidationFrontier(evaluations)
 	require.Len(t, frontier, 3)
-	assert.Equal(t, "candidate-a", frontier[0].CandidateID)
-	assert.Equal(t, "candidate-a", frontier[1].CandidateID)
-	assert.Equal(t, "candidate-b", frontier[2].CandidateID)
-	assert.Equal(t, 2, coverage["candidate-a"])
-	assert.Equal(t, 1, coverage["candidate-b"])
+	assert.Equal(t, []string{"candidate-b"}, frontier[0].CandidateIDs)
+	assert.Equal(t, []string{"candidate-b", "candidate-c"}, frontier[1].CandidateIDs)
+	assert.Equal(t, []string{"candidate-c"}, frontier[2].CandidateIDs)
+	assert.Equal(t, 2, coverage["candidate-b"])
+	assert.Equal(t, 2, coverage["candidate-c"])
+	assert.NotContains(t, coverage, "candidate-a")
+}
+
+func TestBuildValidationFrontierPrunesDominatedTiedWinners(t *testing.T) {
+	evaluations := map[string]*gepaCandidateEvaluation{
+		"candidate-a": {
+			Cases: []gepaEvaluationCase{
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-0"}}, Score: 1.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "a-1"}}, Score: 0.0},
+			},
+			AverageScore: 0.5,
+		},
+		"candidate-b": {
+			Cases: []gepaEvaluationCase{
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-0"}}, Score: 1.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "b-1"}}, Score: 1.0},
+			},
+			AverageScore: 1.0,
+		},
+		"candidate-c": {
+			Cases: []gepaEvaluationCase{
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "c-0"}}, Score: 0.0},
+				{Example: core.Example{Outputs: map[string]interface{}{"output": "c-1"}}, Score: 1.0},
+			},
+			AverageScore: 0.5,
+		},
+	}
+
+	frontier, coverage := buildValidationFrontier(evaluations)
+	require.Len(t, frontier, 2)
+	assert.Equal(t, []string{"candidate-b"}, frontier[0].CandidateIDs)
+	assert.Equal(t, []string{"candidate-b"}, frontier[1].CandidateIDs)
+	assert.Equal(t, 2, coverage["candidate-b"])
+	assert.NotContains(t, coverage, "candidate-a")
+	assert.NotContains(t, coverage, "candidate-c")
 }
 
 func TestValidateIfScheduledHonorsValidationFrequency(t *testing.T) {
@@ -1124,9 +1169,9 @@ func TestValidationSelectionPopulationUsesFrontierCoverage(t *testing.T) {
 	})
 	gepa.state.SetValidationFrontier(
 		map[int]*gepaValidationFrontierEntry{
-			0: {CaseIndex: 0, CandidateID: "candidate-a", Score: 0.4},
-			1: {CaseIndex: 1, CandidateID: "candidate-a", Score: 0.4},
-			2: {CaseIndex: 2, CandidateID: "candidate-b", Score: 0.9},
+			0: {CaseIndex: 0, CandidateID: "candidate-a", CandidateIDs: []string{"candidate-a"}, Score: 0.4},
+			1: {CaseIndex: 1, CandidateID: "candidate-a", CandidateIDs: []string{"candidate-a", "candidate-b"}, Score: 0.4},
+			2: {CaseIndex: 2, CandidateID: "candidate-b", CandidateIDs: []string{"candidate-b"}, Score: 0.9},
 		},
 		map[string]int{
 			"candidate-a": 2,
@@ -1166,7 +1211,7 @@ func TestSelectCandidateForUpdatePrefersValidationFrontierContributor(t *testing
 	})
 	gepa.state.SetValidationFrontier(
 		map[int]*gepaValidationFrontierEntry{
-			0: {CaseIndex: 0, CandidateID: "candidate-a", Score: 0.4},
+			0: {CaseIndex: 0, CandidateID: "candidate-a", CandidateIDs: []string{"candidate-a"}, Score: 0.4},
 		},
 		map[string]int{
 			"candidate-a": 1,


### PR DESCRIPTION
## Summary
- keep tied-best validation candidates per example instead of collapsing to one winner immediately
- prune dominated tied candidates before deriving frontier coverage for validation-guided selection
- add unit coverage for complementary frontier retention and dominated-tie pruning

## Verification
- go test ./pkg/optimizers -run 'TestBuildValidationFrontierTracksCoverage|TestBuildValidationFrontierPrunesDominatedTiedWinners|TestValidationSelectionPopulationUsesFrontierCoverage|TestSelectCandidateForUpdatePrefersValidationFrontierContributor|TestEvaluateValidationPopulationTracksBestCandidate' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- golangci-lint run ./...
- ./compatibility_test/run_gepa_fixture.sh