### PR TITLE
GEPA: refine ancestor merge proposals

### DIFF
--- a/pkg/optimizers/gepa.go
+++ b/pkg/optimizers/gepa.go
@@ -104,6 +104,7 @@ type GEPAConfig struct {
 	ValidationFrequency int     `json:"validation_frequency"`  // Default: 1
 	ValidationSplit     float64 `json:"validation_split"`      // Default: 0.0 (disabled)
 	RandomSeed          int64   `json:"random_seed"`           // Default: 0 (time-based)
+	MaxMergeInvocations int     `json:"max_merge_invocations"` // Default: 5
 
 	// LLM parameters
 	GenerationModel string  `json:"generation_model"` // Default: uses core.GetDefaultLLM()
@@ -132,6 +133,7 @@ func DefaultGEPAConfig() *GEPAConfig {
 		ConcurrencyLevel:     3,
 		ValidationFrequency:  1,
 		ValidationSplit:      0.0,
+		MaxMergeInvocations:  5,
 		Temperature:          0.8,
 		MaxTokens:            500,
 	}
@@ -360,6 +362,8 @@ type GEPAState struct {
 	MultiObjectiveFitnessMap map[string]*MultiObjectiveFitness    `json:"multi_objective_fitness_map"`
 	ValidationFrontier       map[int]*gepaValidationFrontierEntry `json:"validation_frontier,omitempty"`
 	ValidationCoverage       map[string]int                       `json:"validation_coverage,omitempty"`
+	MergeInvocations         int                                  `json:"merge_invocations,omitempty"`
+	PerformedMerges          map[string]bool                      `json:"performed_merges,omitempty"`
 	candidateReflections     map[string]*ReflectionResult
 	candidateEvaluations     map[string]*gepaCandidateEvaluation
 	candidateValidationEvals map[string]*gepaCandidateEvaluation
@@ -387,6 +391,7 @@ func NewGEPAState() *GEPAState {
 		MultiObjectiveFitnessMap: make(map[string]*MultiObjectiveFitness),
 		ValidationFrontier:       make(map[int]*gepaValidationFrontierEntry),
 		ValidationCoverage:       make(map[string]int),
+		PerformedMerges:          make(map[string]bool),
 		candidateReflections:     make(map[string]*ReflectionResult),
 		candidateEvaluations:     make(map[string]*gepaCandidateEvaluation),
 		candidateValidationEvals: make(map[string]*gepaCandidateEvaluation),
@@ -601,6 +606,52 @@ func (s *GEPAState) ValidationFrontierSnapshot() (map[int]*gepaValidationFrontie
 	}
 
 	return frontier, coverage
+}
+
+func (s *GEPAState) HasRecordedMerge(key string) bool {
+	if s == nil || strings.TrimSpace(key) == "" {
+		return false
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.PerformedMerges[key]
+}
+
+func (s *GEPAState) MergeBudgetAvailable(maxInvocations int) bool {
+	if s == nil {
+		return false
+	}
+	if maxInvocations <= 0 {
+		return true
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.MergeInvocations < maxInvocations
+}
+
+func (s *GEPAState) RecordMergeInvocation(key string, maxInvocations int) bool {
+	if s == nil || strings.TrimSpace(key) == "" {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if maxInvocations > 0 && s.MergeInvocations >= maxInvocations {
+		return false
+	}
+	if s.PerformedMerges == nil {
+		s.PerformedMerges = make(map[string]bool)
+	}
+	if s.PerformedMerges[key] {
+		return false
+	}
+
+	s.PerformedMerges[key] = true
+	s.MergeInvocations++
+	return true
 }
 
 func cloneValidationFrontierEntry(entry *gepaValidationFrontierEntry) *gepaValidationFrontierEntry {
@@ -2908,6 +2959,9 @@ func NewGEPA(config *GEPAConfig) (*GEPA, error) {
 	}
 	if config.TournamentSize <= 0 {
 		config.TournamentSize = defaults.TournamentSize
+	}
+	if config.MaxMergeInvocations <= 0 {
+		config.MaxMergeInvocations = defaults.MaxMergeInvocations
 	}
 	if config.SelectionStrategy == "" {
 		config.SelectionStrategy = defaults.SelectionStrategy

--- a/pkg/optimizers/gepa_acceptance_adapter.go
+++ b/pkg/optimizers/gepa_acceptance_adapter.go
@@ -1,6 +1,9 @@
 package optimizers
 
-import "context"
+import (
+	"context"
+	"sort"
+)
 
 func (g *GEPA) setLatestEvaluationAdapter(adapter *gepaEvaluationAdapter) {
 	if g == nil {
@@ -23,6 +26,10 @@ func (g *GEPA) getLatestEvaluationAdapter() *gepaEvaluationAdapter {
 }
 
 func (g *GEPA) acceptCandidateProposal(ctx context.Context, baseline, proposed *GEPACandidate) *GEPACandidate {
+	return g.acceptCandidateProposalWithAdapter(ctx, baseline, proposed, g.getLatestEvaluationAdapter(), nil)
+}
+
+func (g *GEPA) acceptCandidateProposalWithAdapter(ctx context.Context, baseline, proposed *GEPACandidate, adapter *gepaEvaluationAdapter, extraMetadata map[string]interface{}) *GEPACandidate {
 	if baseline == nil || proposed == nil {
 		if proposed != nil {
 			return proposed
@@ -33,13 +40,14 @@ func (g *GEPA) acceptCandidateProposal(ctx context.Context, baseline, proposed *
 		return baseline
 	}
 
-	adapter := g.getLatestEvaluationAdapter()
 	if adapter == nil {
 		return proposed
 	}
 
-	baselineEvaluation := g.cachedOrEvaluateCandidate(ctx, baseline, adapter)
-	if baselineEvaluation != nil && g != nil && g.state != nil {
+	useLatestAdapterCache := adapter == g.getLatestEvaluationAdapter()
+
+	baselineEvaluation := g.cachedOrEvaluateCandidate(ctx, baseline, adapter, useLatestAdapterCache)
+	if useLatestAdapterCache && baselineEvaluation != nil && g != nil && g.state != nil {
 		g.state.UpsertCandidateEvaluation(baseline.ID, baselineEvaluation)
 	}
 
@@ -54,16 +62,20 @@ func (g *GEPA) acceptCandidateProposal(ctx context.Context, baseline, proposed *
 	}
 
 	proposed.Fitness = proposedEvaluation.AverageScore
-	if g != nil && g.state != nil {
+	if useLatestAdapterCache && g != nil && g.state != nil {
 		g.state.UpsertCandidateEvaluation(proposed.ID, proposedEvaluation)
 	}
-	proposed.Metadata = mergeCandidateMetadata(map[string]interface{}{
+	metadata := map[string]interface{}{
 		"proposal_accepted":          true,
 		"proposal_baseline_total":    totalScoreFromEvaluation(baselineEvaluation),
 		"proposal_candidate_total":   totalScoreFromEvaluation(proposedEvaluation),
 		"proposal_baseline_average":  averageScoreFromEvaluation(baselineEvaluation),
 		"proposal_candidate_average": proposedEvaluation.AverageScore,
-	}, proposed.Metadata)
+	}
+	for key, value := range extraMetadata {
+		metadata[key] = value
+	}
+	proposed.Metadata = mergeCandidateMetadata(metadata, proposed.Metadata)
 
 	return proposed
 }
@@ -72,12 +84,71 @@ func (g *GEPA) acceptMutationProposal(ctx context.Context, baseline, proposed *G
 	return g.acceptCandidateProposal(ctx, baseline, proposed)
 }
 
-func (g *GEPA) cachedOrEvaluateCandidate(ctx context.Context, candidate *GEPACandidate, adapter *gepaEvaluationAdapter) *gepaCandidateEvaluation {
+func (g *GEPA) acceptMergeProposal(ctx context.Context, baseline, partner, proposed *GEPACandidate) *GEPACandidate {
+	adapter, metadata := g.buildStratifiedMergeAcceptanceAdapter(ctx, baseline, partner)
+	accepted := g.acceptCandidateProposalWithAdapter(ctx, baseline, proposed, adapter, metadata)
+	if accepted == nil || accepted == baseline {
+		return accepted
+	}
+
+	latestAdapter := g.getLatestEvaluationAdapter()
+	if latestAdapter == nil || latestAdapter == adapter {
+		return accepted
+	}
+
+	latestEvaluation := g.evaluateCandidateWithAdapter(ctx, accepted, latestAdapter)
+	if latestEvaluation == nil {
+		return accepted
+	}
+
+	accepted.Fitness = latestEvaluation.AverageScore
+	if g != nil && g.state != nil {
+		g.state.UpsertCandidateEvaluation(accepted.ID, latestEvaluation)
+	}
+	accepted.Metadata = mergeCandidateMetadata(map[string]interface{}{
+		"merge_post_accept_full_batch_total":   totalScoreFromEvaluation(latestEvaluation),
+		"merge_post_accept_full_batch_average": latestEvaluation.AverageScore,
+	}, accepted.Metadata)
+
+	return accepted
+}
+
+func (g *GEPA) buildStratifiedMergeAcceptanceAdapter(ctx context.Context, baseline, partner *GEPACandidate) (*gepaEvaluationAdapter, map[string]interface{}) {
+	adapter := g.getLatestEvaluationAdapter()
+	if adapter == nil || baseline == nil || partner == nil {
+		return adapter, nil
+	}
+
+	baselineEvaluation := g.cachedOrEvaluateCandidate(ctx, baseline, adapter, true)
+	partnerEvaluation := g.cachedOrEvaluateCandidate(ctx, partner, adapter, true)
+	if baselineEvaluation == nil || partnerEvaluation == nil {
+		return adapter, nil
+	}
+
+	caseIndexes, bucketCounts := stratifiedMergeAcceptanceCaseIndexes(baselineEvaluation, partnerEvaluation)
+	if len(caseIndexes) == 0 {
+		return adapter, map[string]interface{}{
+			"merge_acceptance_mode": "full_batch",
+		}
+	}
+
+	metadata := map[string]interface{}{
+		"merge_acceptance_mode":                 "stratified",
+		"merge_acceptance_case_count":           len(caseIndexes),
+		"merge_acceptance_source_better_count":  bucketCounts.sourceBetter,
+		"merge_acceptance_partner_better_count": bucketCounts.partnerBetter,
+		"merge_acceptance_tied_count":           bucketCounts.tied,
+	}
+
+	return adapter.subset(caseIndexes), metadata
+}
+
+func (g *GEPA) cachedOrEvaluateCandidate(ctx context.Context, candidate *GEPACandidate, adapter *gepaEvaluationAdapter, allowStateCache bool) *gepaCandidateEvaluation {
 	if candidate == nil {
 		return nil
 	}
 
-	if g != nil && g.state != nil {
+	if allowStateCache && g != nil && g.state != nil {
 		if evaluation := g.state.GetCandidateEvaluation(candidate.ID); evaluation != nil {
 			return evaluation
 		}
@@ -100,4 +171,82 @@ func averageScoreFromEvaluation(evaluation *gepaCandidateEvaluation) float64 {
 	}
 
 	return evaluation.AverageScore
+}
+
+type mergeAcceptanceBucketCounts struct {
+	sourceBetter  int
+	partnerBetter int
+	tied          int
+}
+
+func stratifiedMergeAcceptanceCaseIndexes(sourceEvaluation, partnerEvaluation *gepaCandidateEvaluation) ([]int, mergeAcceptanceBucketCounts) {
+	if sourceEvaluation == nil || partnerEvaluation == nil {
+		return nil, mergeAcceptanceBucketCounts{}
+	}
+
+	caseCount := minInt(len(sourceEvaluation.Cases), len(partnerEvaluation.Cases))
+	if caseCount == 0 {
+		return nil, mergeAcceptanceBucketCounts{}
+	}
+
+	sourceBetter := make([]int, 0, caseCount)
+	partnerBetter := make([]int, 0, caseCount)
+	tied := make([]int, 0, caseCount)
+	for caseIndex := 0; caseIndex < caseCount; caseIndex++ {
+		sourceScore := sourceEvaluation.Cases[caseIndex].Score
+		partnerScore := partnerEvaluation.Cases[caseIndex].Score
+		switch {
+		case sourceScore > partnerScore:
+			sourceBetter = append(sourceBetter, caseIndex)
+		case partnerScore > sourceScore:
+			partnerBetter = append(partnerBetter, caseIndex)
+		default:
+			tied = append(tied, caseIndex)
+		}
+	}
+
+	buckets := [][]int{sourceBetter, partnerBetter, tied}
+	nonEmptyBuckets := 0
+	for _, bucket := range buckets {
+		if len(bucket) > 0 {
+			nonEmptyBuckets++
+		}
+	}
+	if nonEmptyBuckets == 0 {
+		return nil, mergeAcceptanceBucketCounts{}
+	}
+
+	targetSize := minInt(caseCount, nonEmptyBuckets*2)
+	selected := make([]int, 0, targetSize)
+	for len(selected) < targetSize {
+		progressed := false
+		for bucketIndex := range buckets {
+			if len(buckets[bucketIndex]) == 0 {
+				continue
+			}
+			selected = append(selected, buckets[bucketIndex][0])
+			buckets[bucketIndex] = buckets[bucketIndex][1:]
+			progressed = true
+			if len(selected) == targetSize {
+				break
+			}
+		}
+		if !progressed {
+			break
+		}
+	}
+	sort.Ints(selected)
+
+	return selected, mergeAcceptanceBucketCounts{
+		sourceBetter:  len(sourceBetter),
+		partnerBetter: len(partnerBetter),
+		tied:          len(tied),
+	}
+}
+
+func minInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
 }

--- a/pkg/optimizers/gepa_evaluation_adapter.go
+++ b/pkg/optimizers/gepa_evaluation_adapter.go
@@ -32,6 +32,32 @@ type gepaEvaluationAdapter struct {
 	metric      core.Metric
 }
 
+func (a *gepaEvaluationAdapter) subset(caseIndexes []int) *gepaEvaluationAdapter {
+	if a == nil {
+		return nil
+	}
+	if len(caseIndexes) == 0 || len(caseIndexes) >= len(a.batch) {
+		return a
+	}
+
+	batch := make([]core.Example, 0, len(caseIndexes))
+	for _, caseIndex := range caseIndexes {
+		if caseIndex < 0 || caseIndex >= len(a.batch) {
+			continue
+		}
+		batch = append(batch, cloneEvaluationExample(a.batch[caseIndex]))
+	}
+	if len(batch) == 0 {
+		return a
+	}
+
+	return &gepaEvaluationAdapter{
+		baseProgram: a.baseProgram,
+		batch:       batch,
+		metric:      a.metric,
+	}
+}
+
 func (g *GEPA) newEvaluationAdapter(program core.Program, dataset core.Dataset, metric core.Metric) *gepaEvaluationAdapter {
 	return &gepaEvaluationAdapter{
 		baseProgram: program,

--- a/pkg/optimizers/gepa_merge_adapter.go
+++ b/pkg/optimizers/gepa_merge_adapter.go
@@ -2,6 +2,7 @@ package optimizers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -12,11 +13,19 @@ type gepaAncestorMergeChoice struct {
 	adoptedComponents     []string
 	conflictingComponents []string
 	coverage              int
+	mergeKey              string
 }
 
 func (g *GEPA) tryAncestorMergeProposal(ctx context.Context, population *Population, source *GEPACandidate, nextGeneration int) *GEPACandidate {
+	if g == nil || g.state == nil || !g.state.MergeBudgetAvailable(g.config.MaxMergeInvocations) {
+		return nil
+	}
+
 	choice := g.selectAncestorMergePartner(population, source)
 	if choice == nil {
+		return nil
+	}
+	if !g.state.RecordMergeInvocation(choice.mergeKey, g.config.MaxMergeInvocations) {
 		return nil
 	}
 
@@ -25,7 +34,7 @@ func (g *GEPA) tryAncestorMergeProposal(ctx context.Context, population *Populat
 		return nil
 	}
 
-	accepted := g.acceptCandidateProposal(ctx, source, merged)
+	accepted := g.acceptMergeProposal(ctx, source, choice.partner, merged)
 	if accepted == nil || accepted == source {
 		return nil
 	}
@@ -68,6 +77,10 @@ func (g *GEPA) selectAncestorMergePartner(population *Population, source *GEPACa
 			adoptedComponents:     adopted,
 			conflictingComponents: conflicts,
 			coverage:              coverage[candidate.ID],
+			mergeKey:              buildAncestorMergeAttemptKey(source.ID, candidate.ID, ancestor.ID, adopted),
+		}
+		if g.state.HasRecordedMerge(choice.mergeKey) {
+			continue
 		}
 		if isBetterAncestorMergeChoice(choice, best) {
 			best = choice
@@ -102,6 +115,9 @@ func (g *GEPA) buildAncestorMergedCandidate(source *GEPACandidate, choice *gepaA
 	if source == nil || choice == nil || choice.partner == nil || choice.ancestor == nil || len(choice.adoptedComponents) == 0 {
 		return nil
 	}
+	if choice.mergeKey == "" {
+		choice.mergeKey = buildAncestorMergeAttemptKey(source.ID, choice.partner.ID, choice.ancestor.ID, choice.adoptedComponents)
+	}
 
 	componentTexts := cloneCandidateComponentTexts(source)
 	if len(componentTexts) == 0 {
@@ -130,10 +146,34 @@ func (g *GEPA) buildAncestorMergedCandidate(source *GEPACandidate, choice *gepaA
 			"proposal_type":                "ancestor_merge",
 			"merge_partner_id":             choice.partner.ID,
 			"merge_common_ancestor_id":     choice.ancestor.ID,
+			"merge_attempt_key":            choice.mergeKey,
 			"merge_adopted_components":     append([]string(nil), choice.adoptedComponents...),
 			"merge_conflicting_components": append([]string(nil), choice.conflictingComponents...),
 		}, source.Metadata, choice.partner.Metadata),
 	}
+}
+
+func buildAncestorMergeAttemptKey(sourceID, partnerID, ancestorID string, adoptedComponents []string) string {
+	components := append([]string(nil), adoptedComponents...)
+	if len(components) > 0 {
+		components = componentModuleNames(stringSliceSet(components))
+	}
+	return fmt.Sprintf("%s|%s|%s|%s", sourceID, partnerID, ancestorID, strings.Join(components, ","))
+}
+
+func stringSliceSet(values []string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	set := make(map[string]string, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		set[value] = value
+	}
+	return set
 }
 
 func mergeableAncestorComponents(source, partner, ancestor *GEPACandidate) ([]string, []string) {

--- a/pkg/optimizers/gepa_test.go
+++ b/pkg/optimizers/gepa_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/XiaoConstantine/dspy-go/internal/testutil"
 	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/datasets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -306,6 +307,7 @@ func TestDefaultGEPAConfig(t *testing.T) {
 	assert.Equal(t, 2, config.ReflectionFreq)
 	assert.Equal(t, 3, config.TournamentSize)
 	assert.Equal(t, componentSelectionRoundRobin, config.ComponentSelection)
+	assert.Equal(t, 5, config.MaxMergeInvocations)
 	assert.Zero(t, config.RandomSeed)
 }
 
@@ -398,6 +400,7 @@ func TestGEPAState(t *testing.T) {
 	assert.NotNil(t, state.candidateValidationEvals)
 	assert.NotNil(t, state.ValidationFrontier)
 	assert.NotNil(t, state.ValidationCoverage)
+	assert.NotNil(t, state.PerformedMerges)
 
 	// Test adding trace
 	trace := &ExecutionTrace{
@@ -2777,9 +2780,10 @@ func TestBuildAncestorMergedCandidateAdoptsPartnerOnlyComponents(t *testing.T) {
 	assert.Equal(t, "ancestor_merge", merged.Metadata["proposal_type"])
 	assert.Equal(t, "partner", merged.Metadata["merge_partner_id"])
 	assert.Equal(t, "ancestor", merged.Metadata["merge_common_ancestor_id"])
+	assert.Equal(t, buildAncestorMergeAttemptKey("source", "partner", "ancestor", []string{"beta"}), merged.Metadata["merge_attempt_key"])
 }
 
-func TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving(t *testing.T) {
+func newAncestorMergeProposalTestFixture() (*GEPA, *Population, *GEPACandidate, *GEPACandidate) {
 	generationLLM := &countingLLM{}
 	gepa := &GEPA{
 		config:        DefaultGEPAConfig(),
@@ -2843,6 +2847,13 @@ func TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving(t *testing
 	)
 	gepa.setLatestEvaluationAdapter(adapter)
 
+	return gepa, current, source, partner
+}
+
+func TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving(t *testing.T) {
+	gepa, current, source, _ := newAncestorMergeProposalTestFixture()
+	generationLLM := gepa.generationLLM.(*countingLLM)
+
 	proposed := gepa.proposeNextGenerationCandidate(context.Background(), current, source, 2)
 	require.NotNil(t, proposed)
 
@@ -2857,9 +2868,154 @@ func TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving(t *testing
 		"beta":  "beta tuned",
 	}, proposed.ComponentTexts)
 	assert.Equal(t, "ancestor_merge", proposed.Metadata["proposal_type"])
+	assert.Equal(t, "stratified", proposed.Metadata["merge_acceptance_mode"])
+	assert.Equal(t, 1, gepa.state.MergeInvocations)
 
 	evaluation := gepa.state.GetCandidateEvaluation(proposed.ID)
 	require.NotNil(t, evaluation)
+	assert.Equal(t, 1.0, evaluation.AverageScore)
+	assert.True(t, gepa.state.PerformedMerges[buildAncestorMergeAttemptKey("source", "partner", "root", []string{"beta"})])
+}
+
+func TestTryAncestorMergeProposalSkipsRecordedMergeAttempts(t *testing.T) {
+	gepa, current, source, _ := newAncestorMergeProposalTestFixture()
+	mergeKey := buildAncestorMergeAttemptKey("source", "partner", "root", []string{"beta"})
+	gepa.state.PerformedMerges[mergeKey] = true
+
+	proposed := gepa.tryAncestorMergeProposal(context.Background(), current, source, 2)
+	assert.Nil(t, proposed)
+	assert.Zero(t, gepa.state.MergeInvocations)
+}
+
+func TestTryAncestorMergeProposalHonorsMergeInvocationCap(t *testing.T) {
+	gepa, current, source, _ := newAncestorMergeProposalTestFixture()
+	gepa.config.MaxMergeInvocations = 1
+	gepa.state.MergeInvocations = 1
+
+	proposed := gepa.tryAncestorMergeProposal(context.Background(), current, source, 2)
+	assert.Nil(t, proposed)
+}
+
+func TestStratifiedMergeAcceptanceCaseIndexesBalancesCases(t *testing.T) {
+	sourceEvaluation := &gepaCandidateEvaluation{
+		Cases: []gepaEvaluationCase{
+			{Score: 1.0},
+			{Score: 1.0},
+			{Score: 1.0},
+			{Score: 1.0},
+			{Score: 1.0},
+			{Score: 0.0},
+			{Score: 0.0},
+		},
+	}
+	partnerEvaluation := &gepaCandidateEvaluation{
+		Cases: []gepaEvaluationCase{
+			{Score: 0.0},
+			{Score: 0.0},
+			{Score: 0.0},
+			{Score: 0.0},
+			{Score: 0.0},
+			{Score: 1.0},
+			{Score: 1.0},
+		},
+	}
+
+	caseIndexes, bucketCounts := stratifiedMergeAcceptanceCaseIndexes(sourceEvaluation, partnerEvaluation)
+	assert.Equal(t, []int{0, 1, 5, 6}, caseIndexes)
+	assert.Equal(t, 5, bucketCounts.sourceBetter)
+	assert.Equal(t, 2, bucketCounts.partnerBetter)
+	assert.Equal(t, 0, bucketCounts.tied)
+}
+
+func TestAcceptMergeProposalReevaluatesAcceptedCandidateOnLatestBatch(t *testing.T) {
+	gepa := &GEPA{
+		config: DefaultGEPAConfig(),
+		state:  NewGEPAState(),
+		rng:    rand.New(rand.NewSource(12)),
+	}
+	gepa.config.EvaluationBatchSize = 7
+
+	source := &GEPACandidate{
+		ID:          "source",
+		ModuleName:  "alpha",
+		Instruction: "alpha tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha tuned",
+			"beta":  "beta base",
+		},
+	}
+	partner := &GEPACandidate{
+		ID:          "partner",
+		ModuleName:  "beta",
+		Instruction: "beta tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha base",
+			"beta":  "beta tuned",
+		},
+	}
+	proposed := &GEPACandidate{
+		ID:          "merged",
+		ModuleName:  "beta",
+		Instruction: "beta tuned",
+		ComponentTexts: map[string]string{
+			"alpha": "alpha tuned",
+			"beta":  "beta tuned",
+		},
+		Metadata: map[string]interface{}{
+			"proposal_type": "ancestor_merge",
+		},
+	}
+
+	dataset := datasets.NewSimpleDataset([]core.Example{
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+		{Outputs: map[string]interface{}{"output": "alpha tuned|beta tuned"}},
+	})
+	adapter := gepa.newEvaluationAdapter(
+		newTwoModuleCandidateEvaluationTestProgram("alpha base", "beta base"),
+		dataset,
+		exactOutputMetric,
+	)
+	gepa.setLatestEvaluationAdapter(adapter)
+	gepa.state.SetCandidateEvaluations(map[string]*gepaCandidateEvaluation{
+		"source": {
+			Cases: []gepaEvaluationCase{
+				{Score: 1.0},
+				{Score: 1.0},
+				{Score: 1.0},
+				{Score: 1.0},
+				{Score: 1.0},
+				{Score: 0.0},
+				{Score: 0.0},
+			},
+		},
+		"partner": {
+			Cases: []gepaEvaluationCase{
+				{Score: 0.0},
+				{Score: 0.0},
+				{Score: 0.0},
+				{Score: 0.0},
+				{Score: 0.0},
+				{Score: 1.0},
+				{Score: 1.0},
+			},
+		},
+	})
+
+	accepted := gepa.acceptMergeProposal(context.Background(), source, partner, proposed)
+	require.NotNil(t, accepted)
+	assert.Equal(t, "stratified", accepted.Metadata["merge_acceptance_mode"])
+	assert.Equal(t, 4, accepted.Metadata["merge_acceptance_case_count"])
+	assert.Equal(t, 4.0, accepted.Metadata["proposal_candidate_total"])
+	assert.Equal(t, 1.0, accepted.Metadata["merge_post_accept_full_batch_average"])
+
+	evaluation := gepa.state.GetCandidateEvaluation(proposed.ID)
+	require.NotNil(t, evaluation)
+	assert.Len(t, evaluation.Cases, 7)
 	assert.Equal(t, 1.0, evaluation.AverageScore)
 }
 


### PR DESCRIPTION
## Summary
- add merge-attempt dedup and a configurable merge invocation cap
- gate ancestor merges with a stratified merge acceptance adapter and keep accepted merge caches aligned with the full latest batch
- add focused tests for merge budget, dedup, and stratified acceptance behavior

## Verification
- go test ./pkg/optimizers -run 'TestDefaultGEPAConfig|TestGEPAState|TestBuildAncestorMergedCandidateAdoptsPartnerOnlyComponents|TestProposeNextGenerationCandidateUsesAncestorMergeWhenImproving|TestTryAncestorMergeProposalSkipsRecordedMergeAttempts|TestTryAncestorMergeProposalHonorsMergeInvocationCap|TestStratifiedMergeAcceptanceCaseIndexesBalancesCases|TestAcceptMergeProposalReevaluatesAcceptedCandidateOnLatestBatch' -count=1
- go test ./pkg/optimizers ./pkg/agents/optimize
- golangci-lint run ./...
- ./compatibility_test/run_gepa_fixture.sh