### PR TITLE
rlm: harden symbolic context discipline

### DIFF
--- a/pkg/modules/rlm/config.go
+++ b/pkg/modules/rlm/config.go
@@ -57,6 +57,14 @@ type Config struct {
 	// Controls max lengths for execution output, variable previews, and history entries.
 	OutputTruncation *OutputTruncationConfig
 
+	// ContextInfoPreviewChars controls how many characters of the loaded context are
+	// exposed in context_info metadata. Set to 0 to disable raw preview text.
+	ContextInfoPreviewChars int
+
+	// MaxFullContextQueryChars limits Query()/QueryBatched() calls that auto-prepend the
+	// full loaded context. Zero disables the guardrail.
+	MaxFullContextQueryChars int
+
 	// OnProgress is called at the start of each iteration with progress info.
 	// Can be used to display progress to users or implement custom termination logic.
 	OnProgress func(progress IterationProgress)
@@ -179,6 +187,8 @@ func DefaultConfig() Config {
 		UseIterationDemos:            false,
 		CompactIterationInstructions: true,
 		OutputTruncation:             outputTruncationConfigPtr(DefaultOutputTruncationConfig()),
+		ContextInfoPreviewChars:      160,
+		MaxFullContextQueryChars:     0,
 	}
 }
 
@@ -385,6 +395,28 @@ func WithOutputTruncationConfig(cfg OutputTruncationConfig) Option {
 			cfg.MaxHistoryEntryLen = 1000
 		}
 		c.OutputTruncation = &cfg
+	}
+}
+
+// WithContextInfoPreviewChars sets the maximum number of raw context characters
+// exposed in context_info metadata. Use 0 to disable preview text entirely.
+func WithContextInfoPreviewChars(n int) Option {
+	return func(c *Config) {
+		if n < 0 {
+			n = 0
+		}
+		c.ContextInfoPreviewChars = n
+	}
+}
+
+// WithMaxFullContextQueryChars limits Query()/QueryBatched() calls that auto-prepend
+// the full loaded context. Use 0 to disable the guardrail.
+func WithMaxFullContextQueryChars(n int) Option {
+	return func(c *Config) {
+		if n < 0 {
+			n = 0
+		}
+		c.MaxFullContextQueryChars = n
 	}
 }
 

--- a/pkg/modules/rlm/repl.go
+++ b/pkg/modules/rlm/repl.go
@@ -346,16 +346,18 @@ func (bh *AsyncBatchHandle) TotalCount() int {
 // additional OS-level resource limits (e.g., cgroups, containers) or running
 // the interpreter in a separate process with strict memory limits.
 type YaegiREPL struct {
-	interp       *interp.Interpreter
-	stdout       *bytes.Buffer
-	stderr       *bytes.Buffer
-	llmClient    SubLLMClient
-	ctx          context.Context
-	mu           sync.Mutex
-	llmCalls     []LLMCall
-	llmCallsMu   sync.Mutex // Separate mutex for async LLM call recording
-	asyncQueries map[string]*AsyncQueryHandle
-	asyncMu      sync.RWMutex
+	interp                   *interp.Interpreter
+	stdout                   *bytes.Buffer
+	stderr                   *bytes.Buffer
+	llmClient                SubLLMClient
+	ctx                      context.Context
+	mu                       sync.Mutex
+	llmCalls                 []LLMCall
+	llmCallsMu               sync.Mutex // Separate mutex for async LLM call recording
+	asyncQueries             map[string]*AsyncQueryHandle
+	asyncMu                  sync.RWMutex
+	contextInfoPreviewChars  int
+	maxFullContextQueryChars int
 
 	// State-verified completion (Nightjar Algorithm 1 Gap 1)
 	// These fields allow programmatic detection of completion via FINAL()/FINAL_VAR()
@@ -411,12 +413,13 @@ func NewYaegiREPL(client SubLLMClient) (*YaegiREPL, error) {
 	}
 
 	r := &YaegiREPL{
-		interp:       i,
-		stdout:       stdout,
-		stderr:       stderr,
-		llmClient:    client,
-		ctx:          context.Background(),
-		asyncQueries: make(map[string]*AsyncQueryHandle),
+		interp:                  i,
+		stdout:                  stdout,
+		stderr:                  stderr,
+		llmClient:               client,
+		ctx:                     context.Background(),
+		asyncQueries:            make(map[string]*AsyncQueryHandle),
+		contextInfoPreviewChars: contextInfoPreviewLen,
 	}
 	if err := r.injectBuiltins(); err != nil {
 		return nil, fmt.Errorf("failed to inject builtins: %w", err)
@@ -516,6 +519,28 @@ func (r *YaegiREPL) isBuiltinName(name string) bool {
 		}
 	}
 	return false
+}
+
+// SetContextInfoPreviewChars sets how many raw context characters may appear in context_info.
+// Use 0 to expose only structural metadata.
+func (r *YaegiREPL) SetContextInfoPreviewChars(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n < 0 {
+		n = 0
+	}
+	r.contextInfoPreviewChars = n
+}
+
+// SetMaxFullContextQueryChars limits Query()/QueryBatched() calls that auto-prepend the full context.
+// Use 0 to disable the guardrail.
+func (r *YaegiREPL) SetMaxFullContextQueryChars(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n < 0 {
+		n = 0
+	}
+	r.maxFullContextQueryChars = n
 }
 
 // finalAnswer handles FINAL(value) calls from within code blocks.
@@ -800,6 +825,10 @@ func getValuePreview(val any, maxLen int) string {
 }
 
 func formatContextInfo(val any, idx *ContextIndex) string {
+	return formatContextInfoWithPreviewLen(val, idx, contextInfoPreviewLen)
+}
+
+func formatContextInfoWithPreviewLen(val any, idx *ContextIndex, previewLen int) string {
 	parts := []string{fmt.Sprintf("type=%s", getTypeName(val))}
 
 	rv := reflect.ValueOf(val)
@@ -821,7 +850,7 @@ func formatContextInfo(val any, idx *ContextIndex) string {
 		parts = append(parts, fmt.Sprintf("chunks=%d", idx.ChunkCount()))
 	}
 
-	preview := normalizeContextPreview(getValuePreview(val, contextInfoPreviewLen))
+	preview := normalizeContextPreview(getValuePreview(val, previewLen), previewLen)
 	if preview != "" {
 		parts = append(parts, fmt.Sprintf("preview=%q", preview))
 	}
@@ -829,14 +858,14 @@ func formatContextInfo(val any, idx *ContextIndex) string {
 	return strings.Join(parts, ", ")
 }
 
-func normalizeContextPreview(preview string) string {
-	if preview == "" {
+func normalizeContextPreview(preview string, maxLen int) string {
+	if preview == "" || maxLen <= 0 {
 		return ""
 	}
 
 	normalized := strings.Join(strings.Fields(preview), " ")
-	if len(normalized) > contextInfoPreviewLen {
-		return normalized[:contextInfoPreviewLen] + "..."
+	if len(normalized) > maxLen {
+		return normalized[:maxLen] + "..."
 	}
 	return normalized
 }
@@ -888,6 +917,11 @@ func (r *YaegiREPL) buildPromptWithContext(prompt string) string {
 // It automatically includes the context variable (if loaded) in the prompt.
 func (r *YaegiREPL) llmQuery(prompt string) string {
 	start := time.Now()
+
+	if blockedMsg, blocked := r.fullContextQueryBlocked("Query"); blocked {
+		r.recordLLMCall(prompt, blockedMsg, 0, 0, 0)
+		return blockedMsg
+	}
 
 	// Get the context variable from the interpreter and include it in the prompt
 	fullPrompt := r.buildPromptWithContext(prompt)
@@ -956,6 +990,15 @@ func (r *YaegiREPL) llmQueryWith(contextSlice, prompt string) string {
 func (r *YaegiREPL) llmQueryBatched(prompts []string) []string {
 	if len(prompts) == 0 {
 		return []string{}
+	}
+
+	if blockedMsg, blocked := r.fullContextQueryBlocked("QueryBatched"); blocked {
+		responses := make([]string, len(prompts))
+		for i, prompt := range prompts {
+			responses[i] = blockedMsg
+			r.recordLLMCall(prompt, blockedMsg, 0, 0, 0)
+		}
+		return responses
 	}
 
 	start := time.Now()
@@ -1257,7 +1300,21 @@ func (r *YaegiREPL) ContextInfo() string {
 		return "context not loaded"
 	}
 
-	return formatContextInfo(v.Interface(), r.contextIndex)
+	return formatContextInfoWithPreviewLen(v.Interface(), r.contextIndex, r.contextInfoPreviewChars)
+}
+
+func (r *YaegiREPL) fullContextQueryBlocked(fnName string) (string, bool) {
+	if r.maxFullContextQueryChars <= 0 || r.contextIndex == nil {
+		return "", false
+	}
+
+	contextSize := len(r.contextIndex.GetRawContent())
+	if contextSize <= r.maxFullContextQueryChars {
+		return "", false
+	}
+
+	return fmt.Sprintf("Error: %s() is disabled for contexts larger than %d chars (loaded context=%d). Use QueryWith or QueryRaw instead.",
+		fnName, r.maxFullContextQueryChars, contextSize), true
 }
 
 // FormatExecutionResult formats an execution result for display.
@@ -1279,6 +1336,11 @@ func FormatExecutionResult(result *ExecutionResult) string {
 // This is called from interpreted code via QueryAsync().
 // It automatically includes the context variable (if loaded) in the prompt.
 func (r *YaegiREPL) llmQueryAsync(prompt string) string {
+	if blockedMsg, blocked := r.fullContextQueryBlocked("QueryAsync"); blocked {
+		r.recordLLMCall(prompt, blockedMsg, 0, 0, 0)
+		return r.completedAsyncHandle(blockedMsg)
+	}
+
 	handle := newAsyncQueryHandle()
 
 	// Build full prompt with context included (capture before goroutine)
@@ -1322,6 +1384,15 @@ func (r *YaegiREPL) llmQueryAsync(prompt string) string {
 // llmQueryBatchedAsync starts batch async queries and returns handle IDs.
 // This is called from interpreted code via QueryBatchedAsync().
 func (r *YaegiREPL) llmQueryBatchedAsync(prompts []string) []string {
+	if blockedMsg, blocked := r.fullContextQueryBlocked("QueryBatchedAsync"); blocked {
+		handleIDs := make([]string, len(prompts))
+		for i, prompt := range prompts {
+			r.recordLLMCall(prompt, blockedMsg, 0, 0, 0)
+			handleIDs[i] = r.completedAsyncHandle(blockedMsg)
+		}
+		return handleIDs
+	}
+
 	handleIDs := make([]string, len(prompts))
 
 	for i, prompt := range prompts {
@@ -1329,6 +1400,17 @@ func (r *YaegiREPL) llmQueryBatchedAsync(prompts []string) []string {
 	}
 
 	return handleIDs
+}
+
+func (r *YaegiREPL) completedAsyncHandle(response string) string {
+	handle := newAsyncQueryHandle()
+
+	r.asyncMu.Lock()
+	r.asyncQueries[handle.id] = handle
+	r.asyncMu.Unlock()
+
+	handle.complete(QueryResponse{Response: response}, nil)
+	return handle.id
 }
 
 // waitAsync blocks until the async query with the given ID completes.

--- a/pkg/modules/rlm/rlm.go
+++ b/pkg/modules/rlm/rlm.go
@@ -354,6 +354,8 @@ func (r *RLM) CompleteWithTrace(ctx context.Context, contextPayload any, query s
 		finalizeRLMTrace(trace, nil, "repl_create_error", fmt.Errorf("failed to create REPL: %w", err))
 		return nil, trace, fmt.Errorf("failed to create REPL: %w", err)
 	}
+	replEnv.SetContextInfoPreviewChars(r.config.ContextInfoPreviewChars)
+	replEnv.SetMaxFullContextQueryChars(r.config.MaxFullContextQueryChars)
 
 	// Load context into REPL
 	if err := replEnv.LoadContext(contextPayload); err != nil {

--- a/pkg/modules/rlm/rlm_test.go
+++ b/pkg/modules/rlm/rlm_test.go
@@ -319,6 +319,8 @@ func TestConfig(t *testing.T) {
 	assert.True(t, cfg.CompactIterationInstructions)
 	require.NotNil(t, cfg.OutputTruncation)
 	assert.Equal(t, DefaultOutputTruncationConfig(), *cfg.OutputTruncation)
+	assert.Equal(t, 160, cfg.ContextInfoPreviewChars)
+	assert.Equal(t, 0, cfg.MaxFullContextQueryChars)
 
 	// Test options
 	cfg = DefaultConfig()
@@ -348,6 +350,14 @@ func TestConfig(t *testing.T) {
 	cfg = DefaultConfig()
 	WithREPLSetup(func(repl *YaegiREPL) error { return nil })(&cfg)
 	assert.NotNil(t, cfg.REPLSetup)
+
+	cfg = DefaultConfig()
+	WithContextInfoPreviewChars(0)(&cfg)
+	assert.Equal(t, 0, cfg.ContextInfoPreviewChars)
+
+	cfg = DefaultConfig()
+	WithMaxFullContextQueryChars(50000)(&cfg)
+	assert.Equal(t, 50000, cfg.MaxFullContextQueryChars)
 }
 
 // TestRLMNew tests the RLM constructor.
@@ -1126,6 +1136,47 @@ fmt.Println(result)
 	assert.Contains(t, execResult.Stdout, "interpreted async response")
 }
 
+func TestAsyncQueryFromInterpreterBlockedAboveFullContextThreshold(t *testing.T) {
+	capturingMock := &promptCapturingMockSubLLMClient{response: "should not be used"}
+
+	repl, err := NewYaegiREPL(capturingMock)
+	require.NoError(t, err)
+	repl.SetMaxFullContextQueryChars(10)
+
+	err = repl.LoadContext("FULL_CONTEXT_MARKER")
+	require.NoError(t, err)
+
+	execResult, err := repl.Execute(context.Background(), `
+handleID := QueryAsync("test async prompt")
+result := WaitAsync(handleID)
+fmt.Println(result)
+`)
+	require.NoError(t, err)
+	assert.Contains(t, execResult.Stdout, "QueryAsync() is disabled for contexts larger than 10 chars")
+	assert.Empty(t, capturingMock.getCapturedPrompts())
+}
+
+func TestAsyncBatchQueryFromInterpreterBlockedAboveFullContextThreshold(t *testing.T) {
+	capturingMock := &promptCapturingMockSubLLMClient{response: "should not be used"}
+
+	repl, err := NewYaegiREPL(capturingMock)
+	require.NoError(t, err)
+	repl.SetMaxFullContextQueryChars(10)
+
+	err = repl.LoadContext("FULL_CONTEXT_MARKER")
+	require.NoError(t, err)
+
+	execResult, err := repl.Execute(context.Background(), `
+handleIDs := QueryBatchedAsync([]string{"prompt1", "prompt2"})
+for _, handleID := range handleIDs {
+    fmt.Println(WaitAsync(handleID))
+}
+`)
+	require.NoError(t, err)
+	assert.Contains(t, execResult.Stdout, "QueryBatchedAsync() is disabled for contexts larger than 10 chars")
+	assert.Empty(t, capturingMock.getCapturedPrompts())
+}
+
 // TestPendingAsyncQueries tests tracking of pending queries.
 func TestPendingAsyncQueries(t *testing.T) {
 	// Create a slow mock client for testing pending state
@@ -1438,6 +1489,25 @@ fmt.Println(result1, result2)
 	// Second prompt (QueryRaw) should NOT have context
 	assert.NotContains(t, prompts[1], "FULL_CONTEXT_MARKER")
 	assert.Equal(t, "Second query", prompts[1])
+}
+
+func TestQueryBlockedAboveFullContextThreshold(t *testing.T) {
+	capturingMock := &promptCapturingMockSubLLMClient{response: "should not be used"}
+
+	repl, err := NewYaegiREPL(capturingMock)
+	require.NoError(t, err)
+	repl.SetMaxFullContextQueryChars(10)
+
+	err = repl.LoadContext("FULL_CONTEXT_MARKER")
+	require.NoError(t, err)
+
+	execResult, err := repl.Execute(context.Background(), `
+result := Query("First query")
+fmt.Println(result)
+`)
+	require.NoError(t, err)
+	assert.Contains(t, execResult.Stdout, "Query() is disabled for contexts larger than 10 chars")
+	assert.Empty(t, capturingMock.getCapturedPrompts())
 }
 
 // TestQueryBatchedRaw tests batched queries without context prepending.
@@ -1872,6 +1942,22 @@ func TestContextInfoString(t *testing.T) {
 	assert.Contains(t, info, "lines=3")
 	assert.Contains(t, info, "chunks=1")
 	assert.Contains(t, info, `preview="alpha beta gamma"`)
+}
+
+func TestContextInfoStringWithoutPreview(t *testing.T) {
+	client := &mockSubLLMClient{queryResponse: "test"}
+	repl, err := NewYaegiREPL(client)
+	require.NoError(t, err)
+	repl.SetContextInfoPreviewChars(0)
+
+	err = repl.LoadContext("alpha\nbeta\ngamma")
+	require.NoError(t, err)
+
+	info := repl.ContextInfo()
+
+	assert.Contains(t, info, "type=string")
+	assert.Contains(t, info, "chars=16")
+	assert.NotContains(t, info, "preview=")
 }
 
 func TestContextInfoStructured(t *testing.T) {

--- a/pkg/modules/rlm/signatures.go
+++ b/pkg/modules/rlm/signatures.go
@@ -34,6 +34,7 @@ Available functions:
 
 Rules:
 - Large contexts: prefer FindRelevant + QueryWith or QueryRaw; avoid Query on large payloads
+- Query() already prepends the full context; do not concatenate context into its prompt
 - Write short executable Go statements only; no imports, no type declarations, no top-level funcs
 - Declare every variable before use
 - When you know the answer from code, call FINAL() or FINAL_VAR() immediately
@@ -82,13 +83,14 @@ COMPLETION FUNCTIONS:
 STANDARD GO: fmt, strings, regexp, strconv, encoding/json, sort
 
 CRITICAL - CONTEXT SIZE HANDLING:
-- Context < 50K chars: Use Query(prompt + context) directly
+- Context < 50K chars: Use Query(prompt) directly
 - Context 50K-200K chars: Use QueryWith(context, prompt) to control what's sent
 - Context > 200K chars: MUST chunk! Use FindRelevant() or split manually, then QueryWith() or QueryRaw()
 
 WARNING: Query() auto-prepends the ENTIRE context (~4 chars = 1 token). For a 500K char context:
   Query("analyze: " + context[:100000])  // WRONG! Sends 500K + 100K = 600K chars (overflow!)
   QueryWith(context[:100000], "analyze") // CORRECT! Sends only 100K chars
+  Query("analyze")                        // CORRECT for small contexts only; full context is added automatically
 
 LARGE CONTEXT PATTERN:
 // For contexts > 200K chars, chunk and query separately:
@@ -109,6 +111,7 @@ CRITICAL CODE RULES (violations cause errors):
 - Write ONLY executable statements (assignments, function calls, loops, conditionals)
 - EVERY variable must be declared with := before use
 - Keep code blocks SHORT (under 15 lines)
+- Do NOT append context or chunk text to Query() prompts; use QueryWith or QueryRaw when you need explicit slices
 
 CRITICAL - SIGNALING COMPLETION:
 When you have the answer, IMMEDIATELY call FINAL() in the SAME code block!
@@ -320,7 +323,7 @@ func IterationDemos() []core.Example {
 				"repl_state":   "context: <loaded>",
 			},
 			Outputs: map[string]interface{}{
-				"reasoning": "Context is too large to process at once. I'll chunk it and use QueryBatched for parallel analysis.",
+				"reasoning": "Context is too large to process at once. I'll chunk it and use QueryBatchedRaw so each prompt carries only its own slice.",
 				"action":    "query",
 				"code": `chunkSize := len(context) / 5
 var prompts []string
@@ -329,7 +332,7 @@ for i := 0; i < 5; i++ {
     if i == 4 { end = len(context) }
     prompts = append(prompts, fmt.Sprintf("Find any secret codes in this text. Return ONLY the code if found, or 'none' if not found: %s", context[start:end]))
 }
-results := QueryBatched(prompts)
+results := QueryBatchedRaw(prompts)
 for i, r := range results { fmt.Printf("Chunk %d: %s\n", i, r) }`,
 				"subquery": "",
 				"answer":   "",
@@ -361,7 +364,7 @@ for i, r := range results { fmt.Printf("Chunk %d: %s\n", i, r) }`,
 			Outputs: map[string]interface{}{
 				"reasoning": "Small context that fits in one Query call. I'll ask the sub-LLM to determine the label and IMMEDIATELY call FINAL with the result.",
 				"action":    "query",
-				"code": `answer := Query("What is the label in this text? Return ONLY 'correct' or 'incorrect': " + context)
+				"code": `answer := Query("What is the label in this text? Return ONLY 'correct' or 'incorrect'.")
 FINAL(answer)`,
 				"subquery": "",
 				"answer":   "",


### PR DESCRIPTION
## Summary
- add opt-in guardrails for symbolic context discipline in the RLM REPL/config
- allow disabling raw context previews and limiting full-context Query* calls
- fix iteration instructions and demos so they stop teaching Query(prompt + context)
- add regression tests for preview suppression and sync/async query guardrails

## Testing
- go test ./pkg/modules/rlm