### PR TITLE
Add native tool interceptors, dual-channel observations, and richer agent events

### DIFF
--- a/pkg/agents/events.go
+++ b/pkg/agents/events.go
@@ -1,6 +1,22 @@
 package agents
 
-import "time"
+import (
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+)
+
+const (
+	EventRunStarted       = "run_started"
+	EventRunFinished      = "run_finished"
+	EventRunFailed        = "run_failed"
+	EventLLMTurnStarted   = "llm_turn_started"
+	EventLLMTurnFinished  = "llm_turn_finished"
+	EventToolCallProposed = "tool_call_proposed"
+	EventToolCallStarted  = "tool_call_started"
+	EventToolCallBlocked  = "tool_call_blocked"
+	EventToolCallFinished = "tool_call_finished"
+)
 
 // AgentEvent represents an event emitted during agent execution.
 // This is intentionally minimal and will be extended by streaming/event work.
@@ -10,3 +26,15 @@ type AgentEvent struct {
 	Timestamp time.Time
 }
 
+// EmitEvent safely emits an agent event to an optional callback.
+func EmitEvent(onEvent func(AgentEvent), eventType string, data map[string]any) {
+	if onEvent == nil {
+		return
+	}
+
+	onEvent(AgentEvent{
+		Type:      eventType,
+		Data:      core.ShallowCopyMap(data),
+		Timestamp: time.Now().UTC(),
+	})
+}

--- a/pkg/agents/native/agent.go
+++ b/pkg/agents/native/agent.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -25,6 +26,8 @@ type Config struct {
 	ToolPolicy                    string
 	FinishToolText                string
 	MaxConsecutiveNoCallResponses int
+	ToolInterceptors              []core.ToolInterceptor
+	OnEvent                       func(agents.AgentEvent)
 }
 
 // TokenUsage captures aggregate token usage for one tool-calling run.
@@ -78,27 +81,37 @@ func (t *Trace) Clone() *Trace {
 
 // TraceStep captures one model/tool turn.
 type TraceStep struct {
-	Index         int               `json:"index"`
-	AssistantText string            `json:"assistant_text,omitempty"`
-	ToolName      string            `json:"tool_name,omitempty"`
-	Arguments     map[string]any    `json:"arguments,omitempty"`
-	Observation   string            `json:"observation,omitempty"`
-	IsError       bool              `json:"is_error,omitempty"`
-	Usage         TokenUsage        `json:"usage,omitempty"`
-	Metadata      map[string]string `json:"metadata,omitempty"`
+	Index              int               `json:"index"`
+	AssistantText      string            `json:"assistant_text,omitempty"`
+	ToolName           string            `json:"tool_name,omitempty"`
+	Arguments          map[string]any    `json:"arguments,omitempty"`
+	Observation        string            `json:"observation,omitempty"`
+	ObservationDisplay string            `json:"observation_display,omitempty"`
+	ObservationDetails map[string]any    `json:"observation_details,omitempty"`
+	IsError            bool              `json:"is_error,omitempty"`
+	Synthetic          bool              `json:"synthetic,omitempty"`
+	Redacted           bool              `json:"redacted,omitempty"`
+	Truncated          bool              `json:"truncated,omitempty"`
+	Usage              TokenUsage        `json:"usage,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
 }
 
 // Clone returns a deep copy of the step.
 func (s TraceStep) Clone() TraceStep {
 	return TraceStep{
-		Index:         s.Index,
-		AssistantText: s.AssistantText,
-		ToolName:      s.ToolName,
-		Arguments:     core.ShallowCopyMap(s.Arguments),
-		Observation:   s.Observation,
-		IsError:       s.IsError,
-		Usage:         s.Usage,
-		Metadata:      core.ShallowCopyMap(s.Metadata),
+		Index:              s.Index,
+		AssistantText:      s.AssistantText,
+		ToolName:           s.ToolName,
+		Arguments:          core.ShallowCopyMap(s.Arguments),
+		Observation:        s.Observation,
+		ObservationDisplay: s.ObservationDisplay,
+		ObservationDetails: core.ShallowCopyMap(s.ObservationDetails),
+		IsError:            s.IsError,
+		Synthetic:          s.Synthetic,
+		Redacted:           s.Redacted,
+		Truncated:          s.Truncated,
+		Usage:              s.Usage,
+		Metadata:           core.ShallowCopyMap(s.Metadata),
 	}
 }
 
@@ -150,6 +163,7 @@ func NewAgent(llm core.LLM, cfg Config) (*Agent, error) {
 	if cfg.MaxConsecutiveNoCallResponses <= 0 {
 		cfg.MaxConsecutiveNoCallResponses = defaultMaxConsecutiveNoCallResponses
 	}
+	cfg.ToolInterceptors = append([]core.ToolInterceptor(nil), cfg.ToolInterceptors...)
 
 	return &Agent{
 		llm:          llm,
@@ -200,9 +214,23 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 	transcript := make([]toolTurn, 0, maxTurns)
 	noCallStreak := 0
 
+	a.emitEvent(agents.EventRunStarted, map[string]any{
+		"task_id":   taskID,
+		"task":      task,
+		"max_turns": maxTurns,
+		"model":     a.llm.ModelID(),
+		"provider":  a.llm.ProviderName(),
+	})
+
 	for turn := 0; turn < maxTurns; turn++ {
 		options := []core.GenerateOption{core.WithMaxTokens(a.config.MaxTokens)}
 		options = append(options, core.WithTemperature(a.config.Temperature))
+
+		a.emitEvent(agents.EventLLMTurnStarted, map[string]any{
+			"task_id":   taskID,
+			"turn":      turn + 1,
+			"max_turns": maxTurns,
+		})
 
 		result, err := a.generateToolCallResponse(ctx, task, transcript, turn+1, maxTurns, functions, options...)
 		if err != nil {
@@ -210,6 +238,24 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 			trace.Error = err.Error()
 			trace.TokenUsage = totalUsage
 			a.storeTraces(input, trace)
+			a.emitEvent(agents.EventLLMTurnFinished, map[string]any{
+				"task_id":     taskID,
+				"turn":        turn + 1,
+				"tool_calls":  0,
+				"usage_total": int64(0),
+				"error":       err.Error(),
+			})
+			a.emitEvent(agents.EventRunFailed, map[string]any{
+				"task_id": taskID,
+				"error":   err.Error(),
+			})
+			a.emitEvent(agents.EventRunFinished, map[string]any{
+				"task_id":    taskID,
+				"completed":  false,
+				"turns":      len(trace.Steps),
+				"tool_calls": countExecutedTools(trace.Steps),
+				"error":      trace.Error,
+			})
 			return nil, err
 		}
 
@@ -228,13 +274,29 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 
 		calls, err := extractFunctionCalls(result)
 		if err != nil {
+			a.emitEvent(agents.EventLLMTurnFinished, map[string]any{
+				"task_id":        taskID,
+				"turn":           turn + 1,
+				"assistant_text": step.AssistantText,
+				"tool_calls":     0,
+				"usage_total":    step.Usage.TotalTokens,
+				"parse_error":    err.Error(),
+			})
 			step.Observation = err.Error()
+			step.ObservationDisplay = err.Error()
 			step.IsError = true
 			trace.Steps = append(trace.Steps, step)
 			trace.Duration = time.Since(startedAt)
 			trace.Error = err.Error()
 			trace.TokenUsage = totalUsage
 			a.storeTraces(input, trace)
+			a.emitEvent(agents.EventRunFinished, map[string]any{
+				"task_id":    taskID,
+				"completed":  false,
+				"turns":      len(trace.Steps),
+				"tool_calls": countExecutedTools(trace.Steps),
+				"error":      trace.Error,
+			})
 			return map[string]interface{}{
 				"completed":   false,
 				"error":       trace.Error,
@@ -243,6 +305,13 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				"token_usage": tokenUsageToMap(totalUsage),
 			}, nil
 		}
+		a.emitEvent(agents.EventLLMTurnFinished, map[string]any{
+			"task_id":        taskID,
+			"turn":           turn + 1,
+			"assistant_text": step.AssistantText,
+			"tool_calls":     len(calls),
+			"usage_total":    step.Usage.TotalTokens,
+		})
 		if len(calls) == 0 {
 			noCallStreak++
 			observation := "Model returned text without a tool call. It must use a tool or Finish."
@@ -253,6 +322,7 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				observation += " Finish reason: " + finishReason
 			}
 			step.Observation = observation
+			step.ObservationDisplay = observation
 			step.IsError = true
 			trace.Steps = append(trace.Steps, step)
 			transcript = append(transcript, toolTurn{
@@ -265,6 +335,13 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				trace.Error = fmt.Sprintf("repeated model responses without tool calls after %d turns", noCallStreak)
 				trace.TokenUsage = totalUsage
 				a.storeTraces(input, trace)
+				a.emitEvent(agents.EventRunFinished, map[string]any{
+					"task_id":    taskID,
+					"completed":  false,
+					"turns":      len(trace.Steps),
+					"tool_calls": countExecutedTools(trace.Steps),
+					"error":      trace.Error,
+				})
 				return map[string]interface{}{
 					"completed":   false,
 					"error":       trace.Error,
@@ -290,7 +367,16 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				arguments = map[string]any{}
 			}
 			callStep.ToolName = toolName
+			// Trace the originally proposed call arguments. Interceptors may rewrite
+			// the executed arguments, but proposed values remain useful for debugging
+			// model behavior and policy decisions.
 			callStep.Arguments = core.ShallowCopyMap(arguments)
+			a.emitEvent(agents.EventToolCallProposed, map[string]any{
+				"task_id":   taskID,
+				"turn":      turn + 1,
+				"tool_name": toolName,
+				"arguments": core.ShallowCopyMap(arguments),
+			})
 
 			if strings.EqualFold(toolName, "finish") {
 				finalAnswer := extractFinishAnswer(arguments, callStep.AssistantText)
@@ -300,6 +386,13 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				trace.Duration = time.Since(startedAt)
 				trace.TokenUsage = totalUsage
 				a.storeTraces(input, trace)
+				a.emitEvent(agents.EventRunFinished, map[string]any{
+					"task_id":      taskID,
+					"completed":    true,
+					"turns":        len(trace.Steps),
+					"tool_calls":   countExecutedTools(trace.Steps),
+					"final_answer": finalAnswer,
+				})
 				return map[string]interface{}{
 					"completed":    true,
 					"final_answer": finalAnswer,
@@ -313,6 +406,7 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 			if err != nil {
 				callStep.IsError = true
 				callStep.Observation = fmt.Sprintf("unknown tool %q: %v", toolName, err)
+				callStep.ObservationDisplay = callStep.Observation
 				trace.Steps = append(trace.Steps, callStep)
 				transcript = append(transcript, toolTurn{
 					ToolName:      toolName,
@@ -327,6 +421,7 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 			if err := tool.Validate(arguments); err != nil {
 				callStep.IsError = true
 				callStep.Observation = fmt.Sprintf("invalid tool arguments: %v", err)
+				callStep.ObservationDisplay = callStep.Observation
 				trace.Steps = append(trace.Steps, callStep)
 				transcript = append(transcript, toolTurn{
 					ToolName:      toolName,
@@ -338,16 +433,41 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				continue
 			}
 
-			toolResult, err := tool.Execute(ctx, arguments)
-			if err != nil {
+			a.emitEvent(agents.EventToolCallStarted, map[string]any{
+				"task_id":   taskID,
+				"turn":      turn + 1,
+				"tool_name": toolName,
+				"arguments": core.ShallowCopyMap(arguments),
+			})
+
+			observation, err := a.executeTool(ctx, tool, arguments)
+			if errors.Is(err, core.ErrToolBlocked) {
+				reason := blockedReason(err)
+				observation = agents.BlockedToolObservation(toolName, reason)
 				callStep.IsError = true
-				callStep.Observation = fmt.Sprintf("tool execution failed: %v", err)
-			} else {
-				callStep.Observation = agentutil.StringifyToolResult(toolResult)
-				if isError, _ := toolResult.Metadata["isError"].(bool); isError {
-					callStep.IsError = true
+				a.emitEvent(agents.EventToolCallBlocked, map[string]any{
+					"task_id":   taskID,
+					"turn":      turn + 1,
+					"tool_name": toolName,
+					"arguments": core.ShallowCopyMap(arguments),
+					"reason":    reason,
+				})
+			} else if err != nil {
+				callStep.IsError = true
+				observation = agents.ToolObservation{
+					ModelText:   fmt.Sprintf("tool execution failed: %v", err),
+					DisplayText: fmt.Sprintf("tool execution failed: %v", err),
+					IsError:     true,
 				}
 			}
+
+			callStep.Observation = observation.ModelText
+			callStep.ObservationDisplay = observation.DisplayText
+			callStep.ObservationDetails = observation.Details
+			callStep.IsError = callStep.IsError || observation.IsError
+			callStep.Synthetic = callStep.Synthetic || observation.Synthetic
+			callStep.Redacted = observation.Redacted
+			callStep.Truncated = observation.Truncated
 
 			trace.Steps = append(trace.Steps, callStep)
 			transcript = append(transcript, toolTurn{
@@ -357,6 +477,15 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 				IsError:       callStep.IsError,
 				AssistantText: callStep.AssistantText,
 			})
+			a.emitEvent(agents.EventToolCallFinished, map[string]any{
+				"task_id":   taskID,
+				"turn":      turn + 1,
+				"tool_name": toolName,
+				"is_error":  callStep.IsError,
+				"synthetic": callStep.Synthetic,
+				"redacted":  callStep.Redacted,
+				"truncated": callStep.Truncated,
+			})
 		}
 	}
 
@@ -364,6 +493,13 @@ func (a *Agent) Execute(ctx context.Context, input map[string]interface{}) (map[
 	trace.Error = fmt.Sprintf("max turns reached without Finish after %d turns", maxTurns)
 	trace.TokenUsage = totalUsage
 	a.storeTraces(input, trace)
+	a.emitEvent(agents.EventRunFinished, map[string]any{
+		"task_id":    taskID,
+		"completed":  false,
+		"turns":      len(trace.Steps),
+		"tool_calls": countExecutedTools(trace.Steps),
+		"error":      trace.Error,
+	})
 	return map[string]interface{}{
 		"completed":   false,
 		"error":       trace.Error,
@@ -469,6 +605,25 @@ func (a *Agent) maxTurns(input map[string]interface{}) int {
 		return override
 	}
 	return a.config.MaxTurns
+}
+
+func (a *Agent) emitEvent(eventType string, data map[string]any) {
+	if a == nil {
+		return
+	}
+	agents.EmitEvent(a.config.OnEvent, eventType, data)
+}
+
+func (a *Agent) executeTool(ctx context.Context, tool core.Tool, arguments map[string]any) (agents.ToolObservation, error) {
+	handler := func(ctx context.Context, args map[string]interface{}) (core.ToolResult, error) {
+		return tool.Execute(ctx, args)
+	}
+	info := core.NewToolInfoFromTool(tool)
+	result, err := core.ChainToolInterceptors(a.config.ToolInterceptors...)(ctx, arguments, info, handler)
+	if err != nil {
+		return agents.ToolObservation{}, err
+	}
+	return agents.NormalizeToolResult(result), nil
 }
 
 func (a *Agent) generateToolCallResponse(ctx context.Context, task string, turns []toolTurn, currentTurn int, maxTurns int, functions []map[string]any, options ...core.GenerateOption) (map[string]any, error) {
@@ -609,13 +764,18 @@ func nativeTraceToExecutionTrace(a *Agent, input map[string]interface{}, trace *
 			toolUsage[step.ToolName]++
 		}
 		steps = append(steps, agents.TraceStep{
-			Index:       step.Index,
-			Thought:     step.AssistantText,
-			Tool:        step.ToolName,
-			Arguments:   core.ShallowCopyMap(step.Arguments),
-			Observation: step.Observation,
-			Success:     !step.IsError,
-			Error:       boolError(step.IsError, step.Observation),
+			Index:              step.Index,
+			Thought:            step.AssistantText,
+			Tool:               step.ToolName,
+			Arguments:          core.ShallowCopyMap(step.Arguments),
+			Observation:        step.Observation,
+			ObservationDisplay: step.ObservationDisplay,
+			ObservationDetails: core.ShallowCopyMap(step.ObservationDetails),
+			Success:            !step.IsError,
+			Error:              boolError(step.IsError, step.Observation),
+			Synthetic:          step.Synthetic,
+			Redacted:           step.Redacted,
+			Truncated:          step.Truncated,
 		})
 	}
 
@@ -752,6 +912,14 @@ func cloneRegisteredTool(tool core.Tool) (core.Tool, error) {
 		return nil, fmt.Errorf("tool %q returned nil clone", tool.Name())
 	}
 	return cloned, nil
+}
+
+func blockedReason(err error) string {
+	var blocked *core.ToolBlockedError
+	if errors.As(err, &blocked) && blocked != nil && strings.TrimSpace(blocked.Reason) != "" {
+		return blocked.Reason
+	}
+	return "blocked by tool policy"
 }
 
 func addUsage(total *TokenUsage, raw any) {

--- a/pkg/agents/native/agent_test.go
+++ b/pkg/agents/native/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
 	"github.com/XiaoConstantine/dspy-go/pkg/core"
 	models "github.com/XiaoConstantine/mcp-go/pkg/model"
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,67 @@ func TestAgent_Execute_CompletesWithToolAndFinish(t *testing.T) {
 	assert.Equal(t, "write_note", trace.Steps[0].ToolName)
 	assert.Equal(t, int64(9), trace.TokenUsage.PromptTokens)
 	assert.Equal(t, int64(5), trace.TokenUsage.CompletionTokens)
+}
+
+func TestAgent_Execute_UsesModelTextInTranscriptAndDisplayTextInTrace(t *testing.T) {
+	llm := &stubLLM{
+		capabilities: []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling},
+		results: []map[string]any{
+			{
+				"function_call": map[string]any{
+					"name":      "write_note",
+					"arguments": map[string]any{"content": "done"},
+				},
+			},
+			{
+				"function_call": map[string]any{
+					"name":      "Finish",
+					"arguments": map[string]any{"answer": "done"},
+				},
+			},
+		},
+	}
+
+	agent, err := NewAgent(llm, Config{MaxTurns: 4})
+	require.NoError(t, err)
+	require.NoError(t, agent.RegisterTool(simpleTool{
+		name: "write_note",
+		run: func(ctx context.Context, params map[string]interface{}) (core.ToolResult, error) {
+			return core.ToolResult{
+				Data: "raw output",
+				Metadata: map[string]any{
+					core.ToolResultModelTextMeta:   "summary for model",
+					core.ToolResultDisplayTextMeta: "full output for operator",
+				},
+				Annotations: map[string]any{
+					core.ToolResultDetailsAnnotation: map[string]any{"content": "done"},
+				},
+			}, nil
+		},
+	}))
+
+	result, err := agent.Execute(context.Background(), map[string]interface{}{
+		"task": "Write a note and finish.",
+	})
+	require.NoError(t, err)
+	require.True(t, result["completed"].(bool))
+	require.Len(t, llm.prompts, 2)
+	assert.Contains(t, llm.prompts[1], "summary for model")
+	assert.NotContains(t, llm.prompts[1], "full output for operator")
+
+	trace := agent.LastNativeTrace()
+	require.NotNil(t, trace)
+	require.Len(t, trace.Steps, 2)
+	assert.Equal(t, "summary for model", trace.Steps[0].Observation)
+	assert.Equal(t, "full output for operator", trace.Steps[0].ObservationDisplay)
+	assert.Equal(t, map[string]any{"content": "done"}, trace.Steps[0].ObservationDetails)
+
+	execTrace := agent.LastExecutionTrace()
+	require.NotNil(t, execTrace)
+	require.Len(t, execTrace.Steps, 2)
+	assert.Equal(t, "summary for model", execTrace.Steps[0].Observation)
+	assert.Equal(t, "full output for operator", execTrace.Steps[0].ObservationDisplay)
+	assert.Equal(t, map[string]any{"content": "done"}, execTrace.Steps[0].ObservationDetails)
 }
 
 func TestAgent_Execute_FailsFastAfterRepeatedNoCallResponses(t *testing.T) {
@@ -168,6 +230,163 @@ func TestAgent_Execute_UsesNativeToolCallingWhenAvailable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, llm.messages, 1)
 	assert.Empty(t, llm.prompts)
+}
+
+func TestAgent_Execute_EmitsEventsAndHandlesBlockedTools(t *testing.T) {
+	llm := &stubLLM{
+		capabilities: []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling},
+		results: []map[string]any{
+			{
+				"function_call": map[string]any{
+					"name":      "write_note",
+					"arguments": map[string]any{"content": "blocked"},
+				},
+			},
+			{
+				"function_call": map[string]any{
+					"name":      "Finish",
+					"arguments": map[string]any{"answer": "done"},
+				},
+			},
+		},
+	}
+
+	var events []agents.AgentEvent
+	agent, err := NewAgent(llm, Config{
+		MaxTurns: 4,
+		ToolInterceptors: []core.ToolInterceptor{
+			func(ctx context.Context, args map[string]interface{}, info *core.ToolInfo, handler core.ToolHandler) (core.ToolResult, error) {
+				return core.ToolResult{}, &core.ToolBlockedError{Reason: "approval denied"}
+			},
+		},
+		OnEvent: func(event agents.AgentEvent) {
+			events = append(events, event)
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, agent.RegisterTool(simpleTool{name: "write_note"}))
+
+	result, err := agent.Execute(context.Background(), map[string]interface{}{
+		"task":    "Write a note and finish.",
+		"task_id": "task-blocked",
+	})
+	require.NoError(t, err)
+	require.True(t, result["completed"].(bool))
+	require.Len(t, llm.prompts, 2)
+	assert.Contains(t, llm.prompts[1], `Tool "write_note" blocked: approval denied`)
+
+	trace := agent.LastNativeTrace()
+	require.NotNil(t, trace)
+	require.Len(t, trace.Steps, 2)
+	assert.True(t, trace.Steps[0].Synthetic)
+	assert.True(t, trace.Steps[0].IsError)
+	assert.Contains(t, trace.Steps[0].Observation, "approval denied")
+
+	eventTypes := make([]string, 0, len(events))
+	for _, event := range events {
+		eventTypes = append(eventTypes, event.Type)
+	}
+	assert.Contains(t, eventTypes, agents.EventRunStarted)
+	assert.Contains(t, eventTypes, agents.EventLLMTurnStarted)
+	assert.Contains(t, eventTypes, agents.EventLLMTurnFinished)
+	assert.Contains(t, eventTypes, agents.EventToolCallProposed)
+	assert.Contains(t, eventTypes, agents.EventToolCallStarted)
+	assert.Contains(t, eventTypes, agents.EventToolCallBlocked)
+	assert.Contains(t, eventTypes, agents.EventToolCallFinished)
+	assert.Contains(t, eventTypes, agents.EventRunFinished)
+}
+
+func TestAgent_Execute_HandlesGenericInterceptorError(t *testing.T) {
+	llm := &stubLLM{
+		capabilities: []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling},
+		results: []map[string]any{
+			{
+				"function_call": map[string]any{
+					"name":      "write_note",
+					"arguments": map[string]any{"content": "value"},
+				},
+			},
+			{
+				"function_call": map[string]any{
+					"name":      "Finish",
+					"arguments": map[string]any{"answer": "done"},
+				},
+			},
+		},
+	}
+
+	agent, err := NewAgent(llm, Config{
+		MaxTurns: 4,
+		ToolInterceptors: []core.ToolInterceptor{
+			func(ctx context.Context, args map[string]interface{}, info *core.ToolInfo, handler core.ToolHandler) (core.ToolResult, error) {
+				return core.ToolResult{}, fmt.Errorf("approval backend unavailable")
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, agent.RegisterTool(simpleTool{name: "write_note"}))
+
+	result, err := agent.Execute(context.Background(), map[string]interface{}{
+		"task": "Write a note and finish.",
+	})
+	require.NoError(t, err)
+	require.True(t, result["completed"].(bool))
+	require.Len(t, llm.prompts, 2)
+	assert.Contains(t, llm.prompts[1], "tool execution failed: approval backend unavailable")
+
+	trace := agent.LastNativeTrace()
+	require.NotNil(t, trace)
+	require.Len(t, trace.Steps, 2)
+	assert.False(t, trace.Steps[0].Synthetic)
+	assert.True(t, trace.Steps[0].IsError)
+	assert.Contains(t, trace.Steps[0].Observation, "approval backend unavailable")
+	assert.Contains(t, trace.Steps[0].ObservationDisplay, "approval backend unavailable")
+
+	execTrace := agent.LastExecutionTrace()
+	require.NotNil(t, execTrace)
+	require.Len(t, execTrace.Steps, 2)
+	assert.Contains(t, execTrace.Steps[0].Observation, "approval backend unavailable")
+	assert.Contains(t, execTrace.Steps[0].ObservationDisplay, "approval backend unavailable")
+}
+
+func TestAgent_Execute_EmitsLLMTurnFinishedOnGenerateError(t *testing.T) {
+	llm := &stubLLM{
+		capabilities: []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling},
+	}
+
+	var events []agents.AgentEvent
+	agent, err := NewAgent(llm, Config{
+		MaxTurns: 1,
+		OnEvent: func(event agents.AgentEvent) {
+			events = append(events, event)
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = agent.Execute(context.Background(), map[string]interface{}{
+		"task":    "this will fail",
+		"task_id": "task-generate-error",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no more stubbed results")
+
+	eventTypes := make([]string, 0, len(events))
+	var llmFinished *agents.AgentEvent
+	for i := range events {
+		eventTypes = append(eventTypes, events[i].Type)
+		if events[i].Type == agents.EventLLMTurnFinished {
+			llmFinished = &events[i]
+		}
+	}
+
+	assert.Contains(t, eventTypes, agents.EventLLMTurnStarted)
+	assert.Contains(t, eventTypes, agents.EventLLMTurnFinished)
+	assert.Contains(t, eventTypes, agents.EventRunFailed)
+	assert.Contains(t, eventTypes, agents.EventRunFinished)
+	require.NotNil(t, llmFinished)
+	assert.Equal(t, 0, llmFinished.Data["tool_calls"])
+	assert.Equal(t, int64(0), llmFinished.Data["usage_total"])
+	assert.Contains(t, llmFinished.Data["error"], "no more stubbed results")
 }
 
 func TestAgent_Execute_FallsBackToFunctionsForWrappedFunctionOnlyLLM(t *testing.T) {

--- a/pkg/agents/tool_observation.go
+++ b/pkg/agents/tool_observation.go
@@ -1,0 +1,91 @@
+package agents
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/internal/agentutil"
+)
+
+// ToolObservation separates model-visible output from operator-visible detail.
+type ToolObservation struct {
+	ModelText   string
+	DisplayText string
+	Details     map[string]any
+	IsError     bool
+	Synthetic   bool
+	Redacted    bool
+	Truncated   bool
+}
+
+// NormalizeToolResult converts a ToolResult into a dual-channel observation.
+func NormalizeToolResult(result core.ToolResult) ToolObservation {
+	modelText := core.ToolResultMetadataString(result.Metadata, core.ToolResultModelTextMeta)
+	displayText := core.ToolResultMetadataString(result.Metadata, core.ToolResultDisplayTextMeta)
+	if displayText == "" {
+		displayText = agentutil.StringifyToolResult(result)
+	}
+	if modelText == "" {
+		modelText = displayText
+	}
+
+	return ToolObservation{
+		ModelText:   strings.TrimSpace(modelText),
+		DisplayText: strings.TrimSpace(displayText),
+		Details:     detailsMap(result.Annotations),
+		IsError:     boolMetadataValue(result.Metadata, core.ToolResultIsErrorMeta) || legacyIsError(result.Metadata),
+		Synthetic:   boolMetadataValue(result.Metadata, core.ToolResultSyntheticMeta),
+		Redacted:    boolMetadataValue(result.Metadata, core.ToolResultRedactedMeta),
+		Truncated:   boolMetadataValue(result.Metadata, core.ToolResultTruncatedMeta),
+	}
+}
+
+// BlockedToolObservation creates a synthetic error observation for blocked calls.
+func BlockedToolObservation(toolName string, reason string) ToolObservation {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "blocked by tool policy"
+	}
+	text := fmt.Sprintf("Tool %q blocked: %s", toolName, reason)
+	return ToolObservation{
+		ModelText:   text,
+		DisplayText: text,
+		Details: map[string]any{
+			"tool_name": toolName,
+			"reason":    reason,
+		},
+		IsError:   true,
+		Synthetic: true,
+	}
+}
+
+func boolMetadataValue(metadata map[string]any, key string) bool {
+	if metadata == nil {
+		return false
+	}
+	value, _ := metadata[key].(bool)
+	return value
+}
+
+func legacyIsError(metadata map[string]any) bool {
+	if metadata == nil {
+		return false
+	}
+	value, _ := metadata["isError"].(bool)
+	return value
+}
+
+func detailsMap(annotations map[string]any) map[string]any {
+	if annotations == nil {
+		return nil
+	}
+	raw, ok := annotations[core.ToolResultDetailsAnnotation]
+	if !ok || raw == nil {
+		return nil
+	}
+	if typed, ok := raw.(map[string]any); ok {
+		return core.ShallowCopyMap(typed)
+	}
+	return map[string]any{"value": raw}
+}

--- a/pkg/agents/tool_observation_test.go
+++ b/pkg/agents/tool_observation_test.go
@@ -1,0 +1,60 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeToolResult_UsesDualChannelMetadataWhenPresent(t *testing.T) {
+	observation := NormalizeToolResult(core.ToolResult{
+		Data: "ignored",
+		Metadata: map[string]any{
+			core.ToolResultModelTextMeta:   "model text",
+			core.ToolResultDisplayTextMeta: "display text",
+			core.ToolResultIsErrorMeta:     true,
+			core.ToolResultSyntheticMeta:   true,
+			core.ToolResultRedactedMeta:    true,
+			core.ToolResultTruncatedMeta:   true,
+		},
+		Annotations: map[string]any{
+			core.ToolResultDetailsAnnotation: map[string]any{"command": "pytest"},
+		},
+	})
+
+	assert.Equal(t, "model text", observation.ModelText)
+	assert.Equal(t, "display text", observation.DisplayText)
+	assert.Equal(t, map[string]any{"command": "pytest"}, observation.Details)
+	assert.True(t, observation.IsError)
+	assert.True(t, observation.Synthetic)
+	assert.True(t, observation.Redacted)
+	assert.True(t, observation.Truncated)
+}
+
+func TestNormalizeToolResult_FallsBackToDisplayAndData(t *testing.T) {
+	observation := NormalizeToolResult(core.ToolResult{
+		Data: "raw output",
+	})
+	assert.Equal(t, "raw output", observation.ModelText)
+	assert.Equal(t, "raw output", observation.DisplayText)
+
+	observation = NormalizeToolResult(core.ToolResult{
+		Data: "raw output",
+		Metadata: map[string]any{
+			core.ToolResultDisplayTextMeta: "display only",
+		},
+	})
+	assert.Equal(t, "display only", observation.ModelText)
+	assert.Equal(t, "display only", observation.DisplayText)
+}
+
+func TestBlockedToolObservation_IsSynthetic(t *testing.T) {
+	observation := BlockedToolObservation("bash", "approval denied")
+	require.NotEmpty(t, observation.ModelText)
+	assert.Equal(t, observation.ModelText, observation.DisplayText)
+	assert.True(t, observation.IsError)
+	assert.True(t, observation.Synthetic)
+	assert.Equal(t, "approval denied", observation.Details["reason"])
+}

--- a/pkg/agents/trace.go
+++ b/pkg/agents/trace.go
@@ -17,15 +17,20 @@ const (
 
 // TraceStep represents a structured step in an agent execution.
 type TraceStep struct {
-	Index       int
-	Thought     string
-	ActionRaw   string
-	Tool        string
-	Arguments   map[string]interface{}
-	Observation string
-	Duration    time.Duration
-	Success     bool
-	Error       string
+	Index              int
+	Thought            string
+	ActionRaw          string
+	Tool               string
+	Arguments          map[string]interface{}
+	Observation        string
+	ObservationDisplay string
+	ObservationDetails map[string]any
+	Duration           time.Duration
+	Success            bool
+	Error              string
+	Synthetic          bool
+	Redacted           bool
+	Truncated          bool
 }
 
 // ExecutionTrace captures an agent execution with step-level detail.
@@ -50,15 +55,20 @@ type ExecutionTrace struct {
 // Clone returns a deep copy of the trace step so callers can safely retain it.
 func (s TraceStep) Clone() TraceStep {
 	return TraceStep{
-		Index:       s.Index,
-		Thought:     s.Thought,
-		ActionRaw:   s.ActionRaw,
-		Tool:        s.Tool,
-		Arguments:   core.ShallowCopyMap(s.Arguments),
-		Observation: s.Observation,
-		Duration:    s.Duration,
-		Success:     s.Success,
-		Error:       s.Error,
+		Index:              s.Index,
+		Thought:            s.Thought,
+		ActionRaw:          s.ActionRaw,
+		Tool:               s.Tool,
+		Arguments:          core.ShallowCopyMap(s.Arguments),
+		Observation:        s.Observation,
+		ObservationDisplay: s.ObservationDisplay,
+		ObservationDetails: core.ShallowCopyMap(s.ObservationDetails),
+		Duration:           s.Duration,
+		Success:            s.Success,
+		Error:              s.Error,
+		Synthetic:          s.Synthetic,
+		Redacted:           s.Redacted,
+		Truncated:          s.Truncated,
 	}
 }
 

--- a/pkg/core/tool.go
+++ b/pkg/core/tool.go
@@ -54,6 +54,16 @@ type ToolResult struct {
 	Annotations map[string]interface{} // Additional context for result interpretation
 }
 
+const (
+	ToolResultModelTextMeta     = "agent.model_text"
+	ToolResultDisplayTextMeta   = "agent.display_text"
+	ToolResultIsErrorMeta       = "agent.is_error"
+	ToolResultSyntheticMeta     = "agent.synthetic"
+	ToolResultRedactedMeta      = "agent.redacted"
+	ToolResultTruncatedMeta     = "agent.truncated"
+	ToolResultDetailsAnnotation = "agent.details"
+)
+
 // ToolRegistry manages available tools.
 type ToolRegistry interface {
 	Register(tool Tool) error

--- a/pkg/core/tool_runtime.go
+++ b/pkg/core/tool_runtime.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrToolBlocked = errors.New("tool blocked")
+
+// ToolBlockedError indicates that a tool call was intentionally denied before execution.
+type ToolBlockedError struct {
+	Reason string
+}
+
+func (e *ToolBlockedError) Error() string {
+	if e == nil || e.Reason == "" {
+		return ErrToolBlocked.Error()
+	}
+	return ErrToolBlocked.Error() + ": " + e.Reason
+}
+
+func (e *ToolBlockedError) Unwrap() error {
+	return ErrToolBlocked
+}
+
+// ToolApprovalDecision records the result of a policy or user approval check.
+type ToolApprovalDecision struct {
+	Allowed bool
+	Reason  string
+}
+
+// ToolApprovalFunc decides whether a tool call should be allowed to proceed.
+type ToolApprovalFunc func(ctx context.Context, info *ToolInfo, args map[string]any) (ToolApprovalDecision, error)
+
+// NewToolInfoFromTool creates ToolInfo from a core.Tool while tolerating nil metadata.
+func NewToolInfoFromTool(tool Tool) *ToolInfo {
+	info := NewToolInfo(tool.Name(), tool.Description(), "", tool.InputSchema())
+
+	meta := tool.Metadata()
+	if meta == nil {
+		return info
+	}
+
+	if meta.Version != "" {
+		info.WithVersion(meta.Version)
+	}
+	if len(meta.Capabilities) > 0 {
+		info.WithCapabilities(meta.Capabilities...)
+	}
+	return info
+}
+
+// ToolResultMetadataString returns a string metadata value when present.
+func ToolResultMetadataString(metadata map[string]interface{}, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	value, _ := metadata[key].(string)
+	return value
+}

--- a/pkg/core/tool_runtime_test.go
+++ b/pkg/core/tool_runtime_test.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	models "github.com/XiaoConstantine/mcp-go/pkg/model"
+)
+
+func TestNewToolInfoFromTool_AllowsNilMetadata(t *testing.T) {
+	tool := runtimeStubTool{
+		name:        "nil-meta",
+		description: "nil-meta",
+		schema:      models.InputSchema{Type: "object"},
+	}
+
+	info := NewToolInfoFromTool(tool)
+	require.NotNil(t, info)
+	assert.Equal(t, "nil-meta", info.Name)
+	assert.Equal(t, "nil-meta", info.Description)
+	assert.Equal(t, "1.0.0", info.Version)
+	assert.Empty(t, info.Capabilities)
+}
+
+func TestNewToolInfoFromTool_UsesMetadataWhenPresent(t *testing.T) {
+	tool := runtimeStubTool{
+		name:        "meta",
+		description: "tool-description",
+		schema:      models.InputSchema{Type: "object"},
+		metadata: &ToolMetadata{
+			Name:         "metadata-name",
+			Description:  "metadata-description",
+			Version:      "2.0.0",
+			Capabilities: []string{"read", "write"},
+		},
+	}
+
+	info := NewToolInfoFromTool(tool)
+	require.NotNil(t, info)
+	assert.Equal(t, "meta", info.Name)
+	assert.Equal(t, "tool-description", info.Description)
+	assert.Equal(t, "2.0.0", info.Version)
+	assert.Equal(t, []string{"read", "write"}, info.Capabilities)
+}
+
+type runtimeStubTool struct {
+	name        string
+	description string
+	schema      models.InputSchema
+	metadata    *ToolMetadata
+}
+
+func (t runtimeStubTool) Name() string { return t.name }
+
+func (t runtimeStubTool) Description() string {
+	if t.description != "" {
+		return t.description
+	}
+	return t.name
+}
+
+func (t runtimeStubTool) Metadata() *ToolMetadata { return t.metadata }
+
+func (t runtimeStubTool) CanHandle(context.Context, string) bool { return false }
+
+func (t runtimeStubTool) Execute(context.Context, map[string]interface{}) (ToolResult, error) {
+	return ToolResult{}, nil
+}
+
+func (t runtimeStubTool) Validate(map[string]interface{}) error { return nil }
+
+func (t runtimeStubTool) InputSchema() models.InputSchema { return t.schema }

--- a/pkg/interceptors/tool.go
+++ b/pkg/interceptors/tool.go
@@ -1,0 +1,133 @@
+package interceptors
+
+import (
+	"context"
+	"strings"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/internal/agentutil"
+)
+
+// ApprovalToolInterceptor blocks tool execution when the approval callback denies it.
+func ApprovalToolInterceptor(approve core.ToolApprovalFunc) core.ToolInterceptor {
+	return func(ctx context.Context, args map[string]interface{}, info *core.ToolInfo, handler core.ToolHandler) (core.ToolResult, error) {
+		if approve == nil {
+			return handler(ctx, args)
+		}
+
+		decision, err := approve(ctx, info, core.ShallowCopyMap(args))
+		if err != nil {
+			return core.ToolResult{}, err
+		}
+		if !decision.Allowed {
+			reason := strings.TrimSpace(decision.Reason)
+			if reason == "" {
+				reason = "tool call denied"
+			}
+			return core.ToolResult{}, &core.ToolBlockedError{Reason: reason}
+		}
+
+		return handler(ctx, args)
+	}
+}
+
+// RedactionToolInterceptor rewrites model/display text and details using the provided redactor.
+func RedactionToolInterceptor(redact func(string) string) core.ToolInterceptor {
+	return func(ctx context.Context, args map[string]interface{}, info *core.ToolInfo, handler core.ToolHandler) (core.ToolResult, error) {
+		result, err := handler(ctx, args)
+		if err != nil {
+			return result, err
+		}
+		if redact == nil {
+			return result, nil
+		}
+
+		if result.Metadata == nil {
+			result.Metadata = make(map[string]interface{})
+		}
+		if result.Annotations == nil {
+			result.Annotations = make(map[string]interface{})
+		}
+
+		modelText := core.ToolResultMetadataString(result.Metadata, core.ToolResultModelTextMeta)
+		displayText := core.ToolResultMetadataString(result.Metadata, core.ToolResultDisplayTextMeta)
+		if displayText == "" {
+			displayText = agentutil.StringifyToolResult(result)
+		}
+		if modelText == "" {
+			modelText = displayText
+		}
+
+		redacted := false
+		redactedModel := redact(modelText)
+		redactedDisplay := redact(displayText)
+		if redactedModel != modelText || redactedDisplay != displayText {
+			redacted = true
+		}
+
+		result.Metadata[core.ToolResultModelTextMeta] = redactedModel
+		result.Metadata[core.ToolResultDisplayTextMeta] = redactedDisplay
+
+		if details, ok := result.Annotations[core.ToolResultDetailsAnnotation].(map[string]any); ok {
+			scrubbed := core.ShallowCopyMap(details)
+			for key, value := range scrubbed {
+				text, ok := value.(string)
+				if !ok {
+					continue
+				}
+				updated := redact(text)
+				if updated != text {
+					redacted = true
+				}
+				scrubbed[key] = updated
+			}
+			result.Annotations[core.ToolResultDetailsAnnotation] = scrubbed
+		}
+
+		if redacted {
+			result.Metadata[core.ToolResultRedactedMeta] = true
+		}
+		return result, nil
+	}
+}
+
+// TruncationToolInterceptor trims model/display text while preserving the full raw result.
+func TruncationToolInterceptor(modelLimit int, displayLimit int) core.ToolInterceptor {
+	return func(ctx context.Context, args map[string]interface{}, info *core.ToolInfo, handler core.ToolHandler) (core.ToolResult, error) {
+		result, err := handler(ctx, args)
+		if err != nil {
+			return result, err
+		}
+
+		if result.Metadata == nil {
+			result.Metadata = make(map[string]interface{})
+		}
+
+		modelText := core.ToolResultMetadataString(result.Metadata, core.ToolResultModelTextMeta)
+		displayText := core.ToolResultMetadataString(result.Metadata, core.ToolResultDisplayTextMeta)
+		if displayText == "" {
+			displayText = agentutil.StringifyToolResult(result)
+		}
+		if modelText == "" {
+			modelText = displayText
+		}
+
+		truncated := false
+		if displayLimit > 0 && len(displayText) > displayLimit {
+			displayText = agentutil.TruncateString(displayText, displayLimit)
+			truncated = true
+		}
+		if modelLimit > 0 && len(modelText) > modelLimit {
+			modelText = agentutil.TruncateString(modelText, modelLimit)
+			truncated = true
+		}
+
+		result.Metadata[core.ToolResultModelTextMeta] = modelText
+		result.Metadata[core.ToolResultDisplayTextMeta] = displayText
+		if truncated {
+			result.Metadata[core.ToolResultTruncatedMeta] = true
+		}
+
+		return result, nil
+	}
+}

--- a/pkg/interceptors/tool_test.go
+++ b/pkg/interceptors/tool_test.go
@@ -1,0 +1,88 @@
+package interceptors
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	models "github.com/XiaoConstantine/mcp-go/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApprovalToolInterceptor_BlocksDeniedCalls(t *testing.T) {
+	interceptor := ApprovalToolInterceptor(func(ctx context.Context, info *core.ToolInfo, args map[string]any) (core.ToolApprovalDecision, error) {
+		return core.ToolApprovalDecision{Allowed: false, Reason: "approval denied"}, nil
+	})
+
+	handlerCalled := false
+	_, err := interceptor(context.Background(), map[string]interface{}{"cmd": "rm"}, core.NewToolInfo("bash", "bash", "", models.InputSchema{}), func(ctx context.Context, args map[string]interface{}) (core.ToolResult, error) {
+		handlerCalled = true
+		return core.ToolResult{}, nil
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, core.ErrToolBlocked)
+	assert.False(t, handlerCalled)
+}
+
+func TestApprovalToolInterceptor_AllowsApprovedCalls(t *testing.T) {
+	interceptor := ApprovalToolInterceptor(func(ctx context.Context, info *core.ToolInfo, args map[string]any) (core.ToolApprovalDecision, error) {
+		return core.ToolApprovalDecision{Allowed: true}, nil
+	})
+
+	handlerCalled := false
+	result, err := interceptor(context.Background(), map[string]interface{}{"path": "a.txt"}, core.NewToolInfo("write", "write", "", models.InputSchema{}), func(ctx context.Context, args map[string]interface{}) (core.ToolResult, error) {
+		handlerCalled = true
+		return core.ToolResult{Data: "ok"}, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, handlerCalled)
+	assert.Equal(t, "ok", result.Data)
+}
+
+func TestRedactionToolInterceptor_RedactsTextAndDetails(t *testing.T) {
+	interceptor := RedactionToolInterceptor(func(input string) string {
+		return strings.ReplaceAll(input, "secret", "[REDACTED]")
+	})
+
+	result, err := interceptor(context.Background(), nil, core.NewToolInfo("read", "read", "", models.InputSchema{}), func(ctx context.Context, args map[string]interface{}) (core.ToolResult, error) {
+		return core.ToolResult{
+			Data: "raw secret payload",
+			Metadata: map[string]interface{}{
+				core.ToolResultModelTextMeta:   "model secret text",
+				core.ToolResultDisplayTextMeta: "display secret text",
+			},
+			Annotations: map[string]interface{}{
+				core.ToolResultDetailsAnnotation: map[string]any{
+					"stdout": "secret line",
+				},
+			},
+		}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "model [REDACTED] text", result.Metadata[core.ToolResultModelTextMeta])
+	assert.Equal(t, "display [REDACTED] text", result.Metadata[core.ToolResultDisplayTextMeta])
+	assert.Equal(t, true, result.Metadata[core.ToolResultRedactedMeta])
+	details, ok := result.Annotations[core.ToolResultDetailsAnnotation].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "[REDACTED] line", details["stdout"])
+}
+
+func TestTruncationToolInterceptor_TrimsModelAndDisplayText(t *testing.T) {
+	interceptor := TruncationToolInterceptor(12, 18)
+
+	result, err := interceptor(context.Background(), nil, core.NewToolInfo("read", "read", "", models.InputSchema{}), func(ctx context.Context, args map[string]interface{}) (core.ToolResult, error) {
+		return core.ToolResult{
+			Data: "raw payload that is much longer than the limits",
+			Metadata: map[string]interface{}{
+				core.ToolResultModelTextMeta:   "model payload that is much longer than the limit",
+				core.ToolResultDisplayTextMeta: "display payload that is much longer than the limit",
+			},
+		}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "model pay...", result.Metadata[core.ToolResultModelTextMeta])
+	assert.Equal(t, "display payload...", result.Metadata[core.ToolResultDisplayTextMeta])
+	assert.Equal(t, true, result.Metadata[core.ToolResultTruncatedMeta])
+}


### PR DESCRIPTION
Closes #259

Summary
- route native agent tool execution through the existing ToolInterceptor chain instead of a new middleware abstraction
- add dual-channel tool observation normalization so model-visible text is separated from richer operator/trace details
- expand native agent lifecycle events for run, LLM turn, and tool execution
- add initial approval, redaction, and truncation tool interceptors

What changed
- add ToolResult metadata key constants plus blocking/approval helpers in pkg/core
- add nil-safe ToolInfo construction from core.Tool
- add ToolObservation normalization helpers in pkg/agents
- extend native and generic trace steps with display/details and synthetic/redacted/truncated flags
- wire pkg/agents/native through ToolInterceptor execution, blocked-call handling, and richer event emission
- add tests for normalization fallback, blocked calls, generic interceptor errors, hard LLM errors, and built-in interceptors

Verification
- go test ./pkg/core ./pkg/agents ./pkg/agents/native ./pkg/interceptors

Notes
- this slice is native-agent-first
- ReAct adoption is intentionally deferred