### PR TITLE
Allow flat error message for OpenAI compatible providers

### DIFF
--- a/pkg/llms/openai.go
+++ b/pkg/llms/openai.go
@@ -997,11 +997,21 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
-		fields := errors.Fields{
-			"type": errorResp.Error.Type,
-			"code": errorResp.Error.Code,
+		var errType, errCode, errMsg string
+		if errorResp.Error != nil {
+			errType = errorResp.Error.Type
+			errCode = errorResp.Error.Code
+			errMsg = errorResp.Error.Message
+		} else {
+			errType = errorResp.Type
+			errCode = errorResp.Code
+			errMsg = errorResp.Message
 		}
-		if errorResp.Error.Type == "invalid_request_error" {
+		fields := errors.Fields{
+			"type": errType,
+			"code": errCode,
+		}
+		if errType == "invalid_request_error" {
 			summary := summarizeOpenAIRequest(request, jsonData)
 			dumpPath, dumpErr := writeOpenAIInvalidRequestDebug(request, jsonData, resp.StatusCode, body)
 			logger.Error(
@@ -1015,7 +1025,8 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 				summary.MaxTokens,
 				summary.MaxCompletionTokens,
 				dumpPath,
-				strings.TrimSpace(errorResp.Error.Message),
+				dumpPath,
+				strings.TrimSpace(errMsg),
 			)
 			fields["request_body_bytes"] = summary.BodyBytes
 			fields["request_body_sha256"] = summary.BodySHA256
@@ -1028,7 +1039,7 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 			if dumpErr != nil {
 				fields["debug_dump_error"] = dumpErr.Error()
 			}
-			if allowRetry && shouldRetryOpenAIInvalidJSON(errorResp.Error) {
+			if allowRetry && shouldRetryOpenAIInvalidJSON(errType, errMsg) {
 				logger.Warn(
 					ctx,
 					"Retrying OpenAI request after transient invalid_request_error with a fresh connection: model=%s dump=%s",
@@ -1039,7 +1050,7 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 			}
 		}
 		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, errorResp.Error.Message),
+			errors.New(errors.LLMGenerationFailed, errMsg),
 			fields)
 	}
 
@@ -1051,11 +1062,11 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 	return &response, nil
 }
 
-func shouldRetryOpenAIInvalidJSON(apiError openai.APIError) bool {
-	if apiError.Type != "invalid_request_error" {
+func shouldRetryOpenAIInvalidJSON(errType, errMsg string) bool {
+	if errType != "invalid_request_error" {
 		return false
 	}
-	message := strings.ToLower(strings.TrimSpace(apiError.Message))
+	message := strings.ToLower(strings.TrimSpace(errMsg))
 	return strings.Contains(message, "parse the json body")
 }
 
@@ -1097,9 +1108,19 @@ func (o *OpenAILLM) makeEmbeddingRequest(ctx context.Context, request *openai.Em
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
+		var errType, errCode, errMsg string
+		if errorResp.Error != nil {
+			errType = errorResp.Error.Type
+			errCode = errorResp.Error.Code
+			errMsg = errorResp.Error.Message
+		} else {
+			errType = errorResp.Type
+			errCode = errorResp.Code
+			errMsg = errorResp.Message
+		}
 		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, errorResp.Error.Message),
-			errors.Fields{"type": errorResp.Error.Type, "code": errorResp.Error.Code})
+			errors.New(errors.LLMGenerationFailed, errMsg),
+			errors.Fields{"type": errType, "code": errCode})
 	}
 
 	var response openai.EmbeddingResponse
@@ -1144,9 +1165,19 @@ func (o *OpenAILLM) makeStreamingRequest(ctx context.Context, request *openai.Ch
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
+		var errType, errCode, errMsg string
+		if errorResp.Error != nil {
+			errType = errorResp.Error.Type
+			errCode = errorResp.Error.Code
+			errMsg = errorResp.Error.Message
+		} else {
+			errType = errorResp.Type
+			errCode = errorResp.Code
+			errMsg = errorResp.Message
+		}
 		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, errorResp.Error.Message),
-			errors.Fields{"type": errorResp.Error.Type, "code": errorResp.Error.Code})
+			errors.New(errors.LLMGenerationFailed, errMsg),
+			errors.Fields{"type": errType, "code": errCode})
 	}
 
 	return resp, nil

--- a/pkg/llms/openai.go
+++ b/pkg/llms/openai.go
@@ -997,12 +997,11 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
-		errType, errCode, errMsg := errorResp.GetError()
 		fields := errors.Fields{
-			"type": errType,
-			"code": errCode,
+			"type": errorResp.Error.Type,
+			"code": errorResp.Error.Code,
 		}
-		if errType == "invalid_request_error" {
+		if errorResp.Error.Type == "invalid_request_error" {
 			summary := summarizeOpenAIRequest(request, jsonData)
 			dumpPath, dumpErr := writeOpenAIInvalidRequestDebug(request, jsonData, resp.StatusCode, body)
 			logger.Error(
@@ -1016,7 +1015,7 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 				summary.MaxTokens,
 				summary.MaxCompletionTokens,
 				dumpPath,
-				strings.TrimSpace(errMsg),
+				strings.TrimSpace(errorResp.Error.Message),
 			)
 			fields["request_body_bytes"] = summary.BodyBytes
 			fields["request_body_sha256"] = summary.BodySHA256
@@ -1029,7 +1028,7 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 			if dumpErr != nil {
 				fields["debug_dump_error"] = dumpErr.Error()
 			}
-			if allowRetry && shouldRetryOpenAIInvalidJSON(errType, errMsg) {
+			if allowRetry && shouldRetryOpenAIInvalidJSON(errorResp.Error.Type, errorResp.Error.Message) {
 				logger.Warn(
 					ctx,
 					"Retrying OpenAI request after transient invalid_request_error with a fresh connection: model=%s dump=%s",
@@ -1040,7 +1039,7 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 			}
 		}
 		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, errMsg),
+			errors.New(errors.LLMGenerationFailed, errorResp.Error.Message),
 			fields)
 	}
 
@@ -1098,19 +1097,9 @@ func (o *OpenAILLM) makeEmbeddingRequest(ctx context.Context, request *openai.Em
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
-		var errType, errCode, errMsg string
-		if errorResp.Error != nil {
-			errType = errorResp.Error.Type
-			errCode = errorResp.Error.Code
-			errMsg = errorResp.Error.Message
-		} else {
-			errType = errorResp.Type
-			errCode = errorResp.Code
-			errMsg = errorResp.Message
-		}
 		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, errMsg),
-			errors.Fields{"type": errType, "code": errCode})
+			errors.New(errors.LLMGenerationFailed, errorResp.Error.Message),
+			errors.Fields{"type": errorResp.Error.Type, "code": errorResp.Error.Code})
 	}
 
 	var response openai.EmbeddingResponse
@@ -1155,19 +1144,9 @@ func (o *OpenAILLM) makeStreamingRequest(ctx context.Context, request *openai.Ch
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
-		var errType, errCode, errMsg string
-		if errorResp.Error != nil {
-			errType = errorResp.Error.Type
-			errCode = errorResp.Error.Code
-			errMsg = errorResp.Error.Message
-		} else {
-			errType = errorResp.Type
-			errCode = errorResp.Code
-			errMsg = errorResp.Message
-		}
 		return nil, errors.WithFields(
-			errors.New(errors.LLMGenerationFailed, errMsg),
-			errors.Fields{"type": errType, "code": errCode})
+			errors.New(errors.LLMGenerationFailed, errorResp.Error.Message),
+			errors.Fields{"type": errorResp.Error.Type, "code": errorResp.Error.Code})
 	}
 
 	return resp, nil

--- a/pkg/llms/openai.go
+++ b/pkg/llms/openai.go
@@ -997,16 +997,7 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 				errors.New(errors.LLMGenerationFailed, "API request failed"),
 				errors.Fields{"status": resp.StatusCode, "body": string(body)})
 		}
-		var errType, errCode, errMsg string
-		if errorResp.Error != nil {
-			errType = errorResp.Error.Type
-			errCode = errorResp.Error.Code
-			errMsg = errorResp.Error.Message
-		} else {
-			errType = errorResp.Type
-			errCode = errorResp.Code
-			errMsg = errorResp.Message
-		}
+		errType, errCode, errMsg := errorResp.GetError()
 		fields := errors.Fields{
 			"type": errType,
 			"code": errCode,
@@ -1024,7 +1015,6 @@ func (o *OpenAILLM) makeRequestWithRetry(ctx context.Context, request *openai.Ch
 				summary.ToolChoice,
 				summary.MaxTokens,
 				summary.MaxCompletionTokens,
-				dumpPath,
 				dumpPath,
 				strings.TrimSpace(errMsg),
 			)

--- a/pkg/llms/openai/types.go
+++ b/pkg/llms/openai/types.go
@@ -1,6 +1,9 @@
 package openai
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // ChatCompletionRequest represents a request to the OpenAI Chat Completions API.
 type ChatCompletionRequest struct {
@@ -135,21 +138,32 @@ type APIError struct {
 
 // ErrorResponse represents an error response from the OpenAI API.
 type ErrorResponse struct {
-	Error *APIError `json:"error,omitempty"`
-
-	// fallback for flat structure
-	Message string `json:"message"`
-	Type    string `json:"type"`
-	Param   string `json:"param,omitempty"`
-	Code    string `json:"code,omitempty"`
+	Error APIError `json:"error"`
 }
 
-// GetError returns the error details, prioritizing the nested Error field.
-func (e ErrorResponse) GetError() (errType, errCode, errMsg string) {
-	if e.Error != nil {
-		return e.Error.Type, e.Error.Code, e.Error.Message
+// UnmarshalJSON normalizes the error response format.
+func (e *ErrorResponse) UnmarshalJSON(data []byte) error {
+	type Alias ErrorResponse
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
 	}
-	return e.Type, e.Code, e.Message
+
+	if alias.Error.Message != "" || alias.Error.Type != "" || alias.Error.Code != "" {
+		e.Error = alias.Error
+		return nil
+	}
+
+	var apiError APIError
+	if err := json.Unmarshal(data, &apiError); err != nil {
+		return err
+	}
+
+	if apiError.Message != "" || apiError.Type != "" || apiError.Code != "" {
+		e.Error = apiError
+	}
+
+	return nil
 }
 
 // GenerateOptions holds configuration that can be applied to a chat completion request.

--- a/pkg/llms/openai/types.go
+++ b/pkg/llms/openai/types.go
@@ -144,6 +144,14 @@ type ErrorResponse struct {
 	Code    string `json:"code,omitempty"`
 }
 
+// GetError returns the error details, prioritizing the nested Error field.
+func (e ErrorResponse) GetError() (errType, errCode, errMsg string) {
+	if e.Error != nil {
+		return e.Error.Type, e.Error.Code, e.Error.Message
+	}
+	return e.Type, e.Code, e.Message
+}
+
 // GenerateOptions holds configuration that can be applied to a chat completion request.
 // This mirrors core.GenerateOptions but avoids import cycles.
 type GenerateOptions struct {

--- a/pkg/llms/openai/types.go
+++ b/pkg/llms/openai/types.go
@@ -135,7 +135,13 @@ type APIError struct {
 
 // ErrorResponse represents an error response from the OpenAI API.
 type ErrorResponse struct {
-	Error APIError `json:"error"`
+	Error *APIError `json:"error,omitempty"`
+
+	// fallback for flat structure
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Param   string `json:"param,omitempty"`
+	Code    string `json:"code,omitempty"`
 }
 
 // GenerateOptions holds configuration that can be applied to a chat completion request.

--- a/pkg/llms/openai/types_test.go
+++ b/pkg/llms/openai/types_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,4 +84,73 @@ func TestNewGenerateOptions(t *testing.T) {
 	assert.Equal(t, 0.1, opts.PresencePenalty)
 	assert.Equal(t, -0.2, opts.FrequencyPenalty)
 	assert.Equal(t, []string{"STOP"}, opts.Stop)
+}
+
+func TestErrorResponseUnmarshal(t *testing.T) {
+	t.Run("nested error object", func(t *testing.T) {
+		jsonData := []byte(`{
+			"error": {
+				"message": "nested message",
+				"type": "nested_type",
+				"param": "nested_param",
+				"code": "nested_code"
+			}
+		}`)
+		var resp ErrorResponse
+		err := json.Unmarshal(jsonData, &resp)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, "nested message", resp.Error.Message)
+		assert.Equal(t, "nested_type", resp.Error.Type)
+		assert.Equal(t, "nested_param", resp.Error.Param)
+		assert.Equal(t, "nested_code", resp.Error.Code)
+	})
+
+	t.Run("flat structure", func(t *testing.T) {
+		jsonData := []byte(`{
+			"message": "flat message",
+			"type": "flat_type",
+			"param": "flat_param",
+			"code": "flat_code"
+		}`)
+		var resp ErrorResponse
+		err := json.Unmarshal(jsonData, &resp)
+		require.NoError(t, err)
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, "flat message", resp.Message)
+		assert.Equal(t, "flat_type", resp.Type)
+		assert.Equal(t, "flat_param", resp.Param)
+		assert.Equal(t, "flat_code", resp.Code)
+	})
+}
+
+func TestErrorResponseGetError(t *testing.T) {
+	t.Run("nested error object", func(t *testing.T) {
+		resp := ErrorResponse{
+			Error: &APIError{
+				Message: "nested message",
+				Type:    "nested_type",
+				Code:    "nested_code",
+			},
+			Message: "flat message",
+			Type:    "flat_type",
+			Code:    "flat_code",
+		}
+		errType, errCode, errMsg := resp.GetError()
+		assert.Equal(t, "nested_type", errType)
+		assert.Equal(t, "nested_code", errCode)
+		assert.Equal(t, "nested message", errMsg)
+	})
+
+	t.Run("flat structure", func(t *testing.T) {
+		resp := ErrorResponse{
+			Message: "flat message",
+			Type:    "flat_type",
+			Code:    "flat_code",
+		}
+		errType, errCode, errMsg := resp.GetError()
+		assert.Equal(t, "flat_type", errType)
+		assert.Equal(t, "flat_code", errCode)
+		assert.Equal(t, "flat message", errMsg)
+	})
 }

--- a/pkg/llms/openai/types_test.go
+++ b/pkg/llms/openai/types_test.go
@@ -116,41 +116,37 @@ func TestErrorResponseUnmarshal(t *testing.T) {
 		var resp ErrorResponse
 		err := json.Unmarshal(jsonData, &resp)
 		require.NoError(t, err)
-		assert.Nil(t, resp.Error)
-		assert.Equal(t, "flat message", resp.Message)
-		assert.Equal(t, "flat_type", resp.Type)
-		assert.Equal(t, "flat_param", resp.Param)
-		assert.Equal(t, "flat_code", resp.Code)
+		assert.Equal(t, "flat message", resp.Error.Message)
+		assert.Equal(t, "flat_type", resp.Error.Type)
+		assert.Equal(t, "flat_param", resp.Error.Param)
+		assert.Equal(t, "flat_code", resp.Error.Code)
 	})
 }
 
 func TestErrorResponseGetError(t *testing.T) {
 	t.Run("nested error object", func(t *testing.T) {
 		resp := ErrorResponse{
-			Error: &APIError{
+			Error: APIError{
 				Message: "nested message",
 				Type:    "nested_type",
 				Code:    "nested_code",
 			},
-			Message: "flat message",
-			Type:    "flat_type",
-			Code:    "flat_code",
 		}
-		errType, errCode, errMsg := resp.GetError()
-		assert.Equal(t, "nested_type", errType)
-		assert.Equal(t, "nested_code", errCode)
-		assert.Equal(t, "nested message", errMsg)
+		assert.Equal(t, "nested_type", resp.Error.Type)
+		assert.Equal(t, "nested_code", resp.Error.Code)
+		assert.Equal(t, "nested message", resp.Error.Message)
 	})
 
 	t.Run("flat structure", func(t *testing.T) {
 		resp := ErrorResponse{
-			Message: "flat message",
-			Type:    "flat_type",
-			Code:    "flat_code",
+			Error: APIError{
+				Message: "flat message",
+				Type:    "flat_type",
+				Code:    "flat_code",
+			},
 		}
-		errType, errCode, errMsg := resp.GetError()
-		assert.Equal(t, "flat_type", errType)
-		assert.Equal(t, "flat_code", errCode)
-		assert.Equal(t, "flat message", errMsg)
+		assert.Equal(t, "flat_type", resp.Error.Type)
+		assert.Equal(t, "flat_code", resp.Error.Code)
+		assert.Equal(t, "flat message", resp.Error.Message)
 	})
 }

--- a/pkg/llms/openai_test.go
+++ b/pkg/llms/openai_test.go
@@ -771,7 +771,7 @@ func TestOpenAILLM_ErrorHandling(t *testing.T) {
 		// Return API error
 		w.WriteHeader(http.StatusBadRequest)
 		errorResp := openai.ErrorResponse{
-			Error: openai.APIError{
+			Error: &openai.APIError{
 				Message: "Invalid request",
 				Type:    "invalid_request_error",
 				Code:    "invalid_api_key",

--- a/pkg/llms/openai_test.go
+++ b/pkg/llms/openai_test.go
@@ -771,7 +771,7 @@ func TestOpenAILLM_ErrorHandling(t *testing.T) {
 		// Return API error
 		w.WriteHeader(http.StatusBadRequest)
 		errorResp := openai.ErrorResponse{
-			Error: &openai.APIError{
+			Error: openai.APIError{
 				Message: "Invalid request",
 				Type:    "invalid_request_error",
 				Code:    "invalid_api_key",


### PR DESCRIPTION
Some providers send flat error message. The error message logged provides no information, empty type and code.