### PR TITLE
docs: bump postcss to >=8.5.10 (Dependabot #36)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4337,9 +4337,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,6 +29,9 @@
     "prettier": "^3.6.2",
     "vite": "^7.3.2"
   },
+  "overrides": {
+    "postcss": "^8.5.10"
+  },
   "engines": {
     "node": ">=20.11.0"
   },


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert [#36](https://github.com/XiaoConstantine/dspy-go/security/dependabot/36): postcss `< 8.5.10` XSS via unescaped `</style>` in CSS stringify output (medium severity).
- postcss is a transitive dep under `docs/`. Added an npm `overrides` entry pinning `postcss: ^8.5.10` so the lockfile resolves to a patched version (8.5.12) without exposing postcss as a direct dependency.

## Test plan
- [x] `npm install --package-lock-only` in `docs/` resolves postcss to 8.5.12
- [x] `npm audit` reports 0 vulnerabilities
- [ ] Confirm Dependabot closes alert #36 once merged