### PR TITLE
feat(llms): add OpenAI Codex subscription provider

### DIFF
--- a/docs/architecture/0002-openai-codex-subscription-provider.md
+++ b/docs/architecture/0002-openai-codex-subscription-provider.md
@@ -1,0 +1,64 @@
+# ADR 0002: Keep OpenAI Codex subscription transport separate
+
+## Status
+
+Accepted
+
+## Context
+
+OpenAI API keys and ChatGPT subscription OAuth credentials do not use the same
+wire protocol. API keys use the public OpenAI API. Codex subscription access
+uses `https://chatgpt.com/backend-api/codex/responses`, requires an OAuth bearer
+token plus `ChatGPT-Account-ID`, and returns Responses API server-sent events.
+Routing an OAuth token through the existing Chat Completions provider is both
+incorrect and difficult to audit.
+
+OAuth access tokens are short-lived. Refresh tokens may rotate, and credential
+storage belongs to the consuming application rather than the reusable provider.
+Long-lived agents therefore cannot copy an access token only when the LLM is
+constructed.
+
+## Decision
+
+DSPy-Go registers a distinct `openai-codex` provider implemented in
+`pkg/llms/openai_codex.go`.
+
+The provider:
+
+- resolves credentials immediately before each operation;
+- reports the rejected access token once after an HTTP 401 so refresh rotation can be correlated safely;
+- sends Responses requests with the required account and originator headers;
+- translates canonical chat history, function calls, and function outputs;
+- preserves ordered opaque Responses output items on the canonical message so
+  encrypted reasoning and calls can be replayed exactly on the next turn;
+- parses SSE text, function calls, errors, completion status, and token usage;
+- implements `core.ToolCallingChatLLM`, preserving `pkg/agents.RunLoop` as the
+  sole execution loop;
+- does not offer embeddings, which are not part of subscription Codex access.
+
+The application owns OAuth interaction, permission-restricted persistence, and
+cross-process serialization of rotating refresh tokens. DSPy-Go supplies PKCE,
+independent state generation, context-aware token exchange/refresh helpers, JWT
+account-ID extraction, and the operation-time credential resolver contract.
+
+The ordinary `openai` provider accepts API keys only. Explicit configuration
+wins over `OPENAI_API_KEY`; `OPENAI_OAUTH_TOKEN` is reserved for
+`openai-codex`.
+
+## Consequences
+
+Provider selection is explicit and cannot silently send subscription tokens to
+the wrong host. Applications can refresh credentials without rebuilding agents
+or introducing another execution loop. Consumers must implement a credential
+store and refresh coordinator, which keeps security-sensitive persistence out
+of the reusable provider layer.
+
+## Verification
+
+Recorded-request tests assert the endpoint, headers, Responses payload,
+canonical tool round trip, ordered continuation, SSE usage parsing,
+operation-time resolution, forced refresh retry, and execution through the
+shared `agents.RunLoop`. OAuth tests assert independent state and context
+cancellation. A live ChatGPT subscription smoke test completed a two-turn tool
+call during development; releases should repeat it because it requires
+interactive credentials and validates an external protocol.

--- a/docs/content/docs/reference/providers.md
+++ b/docs/content/docs/reference/providers.md
@@ -249,6 +249,47 @@ llm.SetRetryDelay(time.Second)
 
 ---
 
+## OpenAI Codex Subscription
+
+ChatGPT Plus/Pro subscription access is separate from the API-key OpenAI
+provider. It uses OAuth and `chatgpt.com/backend-api/codex/responses`; never send
+subscription tokens to `api.openai.com/v1/chat/completions`.
+As of this change, the `openai` provider no longer reads `OPENAI_OAUTH_TOKEN`;
+select `openai-codex` explicitly. Explicit OpenAI API-key configuration takes
+precedence over `OPENAI_API_KEY`.
+
+```go
+llm, err := llms.NewOpenAICodexLLM(
+    core.ModelOpenAIGPT54,
+    llms.WithOpenAICodexCredentials(
+        func(ctx context.Context, rejectedAccessToken string) (llms.OpenAICodexCredentials, error) {
+            credential, err := credentialStore.ResolveOpenAI(ctx, rejectedAccessToken)
+            if err != nil {
+                return llms.OpenAICodexCredentials{}, err
+            }
+            return llms.OpenAICodexCredentials{
+                AccessToken: credential.AccessToken,
+                AccountID: credential.AccountID,
+            }, nil
+        },
+    ),
+)
+```
+
+Credentials are resolved before every request. A `401` causes one retry with the rejected access token so concurrent refresh
+rotation can be correlated safely. The application owns secure persistence and cross-process
+serialization of rotating refresh tokens. Use
+`oauth.GetOpenAIAuthorizationURLWithState`, independent `oauth.GenerateState`,
+and the context-aware exchange/refresh helpers. The provider continues to use
+the shared `pkg/agents` execution loop.
+
+For static command-line use, select `openai-codex` and pass the OAuth access
+token in `ProviderConfig.APIKey` or `OPENAI_OAUTH_TOKEN`. Supply `account_id` or
+`id_token` in `ProviderConfig.Params` (or set `OPENAI_ID_TOKEN`); access-token
+account claims remain a compatibility fallback.
+
+---
+
 ## Anthropic Claude
 
 **Best for:** Long context, detailed reasoning, safety

--- a/examples/oauth_login/main.go
+++ b/examples/oauth_login/main.go
@@ -56,7 +56,7 @@ func loginOpenAI() {
 	fmt.Println("OpenAI ChatGPT Plus/Pro OAuth Login")
 	fmt.Println("====================================")
 	fmt.Println()
-	fmt.Println("The token can be used with dspy-go by setting OPENAI_OAUTH_TOKEN.")
+	fmt.Println("The token can be used with the openai-codex provider by setting OPENAI_OAUTH_TOKEN.")
 	fmt.Println()
 
 	if _, err := oauth.LoginOpenAI(); err != nil {

--- a/pkg/agents/clone.go
+++ b/pkg/agents/clone.go
@@ -42,11 +42,12 @@ func CloneMessages(messages []Message) []Message {
 func (m Message) Clone() Message {
 	state := make(cloneState)
 	cloned := Message{
-		ID:        m.ID,
-		Role:      m.Role,
-		Content:   cloneContentBlocksWithState(m.Content, state),
-		ToolCalls: cloneToolCallsWithState(m.ToolCalls, state),
-		Metadata:  cloneAnyMapWithState(m.Metadata, state),
+		ID:           m.ID,
+		Role:         m.Role,
+		Content:      cloneContentBlocksWithState(m.Content, state),
+		ToolCalls:    cloneToolCallsWithState(m.ToolCalls, state),
+		Metadata:     cloneAnyMapWithState(m.Metadata, state),
+		ProviderData: cloneAnyMapWithState(m.ProviderData, state),
 	}
 	if m.ToolResult != nil {
 		result := m.ToolResult.cloneWithState(state)

--- a/pkg/agents/message.go
+++ b/pkg/agents/message.go
@@ -21,12 +21,13 @@ const (
 // This is the agent-level message type; use ToChatMessage() to convert
 // to core.ChatMessage at the LLM boundary.
 type Message struct {
-	ID         string              `json:"id"`
-	Role       MessageRole         `json:"role"`
-	Content    []core.ContentBlock `json:"content"`
-	ToolCalls  []core.ToolCall     `json:"tool_calls,omitempty"`
-	ToolResult *MessageToolResult  `json:"tool_result,omitempty"`
-	Metadata   map[string]any      `json:"metadata,omitempty"`
+	ID           string              `json:"id"`
+	Role         MessageRole         `json:"role"`
+	Content      []core.ContentBlock `json:"content"`
+	ToolCalls    []core.ToolCall     `json:"tool_calls,omitempty"`
+	ToolResult   *MessageToolResult  `json:"tool_result,omitempty"`
+	Metadata     map[string]any      `json:"metadata,omitempty"`
+	ProviderData map[string]any      `json:"provider_data,omitempty"`
 }
 
 // MessageToolResult carries the result of a tool execution at the agent message level.
@@ -110,8 +111,9 @@ func toolResultDisplayContent(result core.ToolResult, displayText string) []core
 
 // ToChatMessage converts an agent-level Message to a core.ChatMessage for the
 // LLM boundary. Agent-only metadata and operator-facing tool details are not
-// included. Use MessagesToChatMessages when converting a transcript so internal
-// messages are filtered rather than represented by placeholders.
+// included. Opaque provider continuation data is carried forward without
+// interpretation. Use MessagesToChatMessages when converting a
+// transcript so internal messages are filtered rather than represented by placeholders.
 func (m Message) ToChatMessage() core.ChatMessage {
 	if !m.ShouldSendToLLM() {
 		// Keep the legacy direct-call behavior valid for callers that convert one
@@ -128,6 +130,7 @@ func (m Message) ToChatMessage() core.ChatMessage {
 		Content:   cloneContentBlocks(m.Content),
 		ToolCalls: cloneToolCalls(m.ToolCalls),
 	}
+	cm.ProviderData = cloneAnyMap(m.ProviderData)
 	if m.ToolResult != nil {
 		cm.ToolResult = &core.ChatToolResult{
 			ToolCallID: m.ToolResult.ToolCallID,
@@ -164,6 +167,7 @@ func MessageFromChatMessage(message core.ChatMessage) Message {
 		Content:   cloneContentBlocks(message.Content),
 		ToolCalls: cloneToolCalls(message.ToolCalls),
 	}
+	converted.ProviderData = cloneAnyMap(message.ProviderData)
 	if message.ToolResult != nil {
 		converted.ToolResult = &MessageToolResult{
 			ToolCallID:     message.ToolResult.ToolCallID,

--- a/pkg/agents/message_test.go
+++ b/pkg/agents/message_test.go
@@ -42,6 +42,21 @@ func TestMessagesToChatMessages_FiltersInternalMessages(t *testing.T) {
 	assert.Equal(t, "hello", chat[1].Content[0].Text)
 }
 
+func TestMessage_ProviderDataRoundTripsThroughDiagnostics(t *testing.T) {
+	message := Message{
+		Role:         RoleAssistant,
+		ProviderData: map[string]any{"openai-codex": []any{map[string]any{"type": "reasoning", "encrypted_content": "opaque"}}},
+	}
+
+	chat := message.ToChatMessage()
+	require.Contains(t, chat.ProviderData, "openai-codex")
+	roundTrip := MessageFromChatMessage(chat)
+	assert.Equal(t, "opaque", roundTrip.ProviderData["openai-codex"].([]any)[0].(map[string]any)["encrypted_content"])
+
+	message.ProviderData["openai-codex"].([]any)[0].(map[string]any)["encrypted_content"] = "changed"
+	assert.Equal(t, "opaque", roundTrip.ProviderData["openai-codex"].([]any)[0].(map[string]any)["encrypted_content"])
+}
+
 func TestNewToolResultMessage_PreservesTypedAndRawPayload(t *testing.T) {
 	result := core.ToolResult{
 		Data: map[string]any{"answer": 42},

--- a/pkg/agents/model.go
+++ b/pkg/agents/model.go
@@ -353,6 +353,14 @@ func normalizeModelResponse(raw map[string]any) (ModelResponse, error) {
 	}
 	response.Message.ToolCalls = calls
 
+	if value, exists := raw["provider_data"]; exists {
+		providerData, ok := value.(map[string]any)
+		if !ok {
+			return ModelResponse{}, fmt.Errorf("provider_data has type %T, want map[string]any", value)
+		}
+		response.Message.ProviderData = cloneAnyMap(providerData)
+	}
+
 	if value, exists := raw["_usage"]; exists {
 		usage, err := normalizeTokenInfo(value)
 		if err != nil {
@@ -364,7 +372,7 @@ func normalizeModelResponse(raw map[string]any) (ModelResponse, error) {
 	diagnostics := make(map[string]any)
 	for key, value := range raw {
 		switch key {
-		case "content", "content_blocks", "tool_calls", "function_call", "_usage":
+		case "content", "content_blocks", "tool_calls", "function_call", "provider_data", "_usage":
 			continue
 		default:
 			if key == "thought_blocks" {

--- a/pkg/agents/model_test.go
+++ b/pkg/agents/model_test.go
@@ -67,6 +67,7 @@ func TestLLMAdapter_CompleteUsesTypedChatBoundary(t *testing.T) {
 	rawArguments := map[string]any{"path": "main.go", "range": map[string]any{"start": 1}}
 	rawMetadata := map[string]any{"signature": []byte{1, 2}}
 	rawDiagnostic := map[string]any{"reason": "test", "nested": map[string]any{"value": "original"}}
+	rawProviderData := map[string]any{"openai-codex": []any{map[string]any{"encrypted_content": "opaque"}}}
 	rawThoughtBlocks := []core.ContentBlock{{
 		Type:     core.FieldTypeImage,
 		Data:     []byte{3, 4},
@@ -86,6 +87,7 @@ func TestLLMAdapter_CompleteUsesTypedChatBoundary(t *testing.T) {
 				Metadata:  rawMetadata,
 			}},
 			"_usage":               usage,
+			"provider_data":        rawProviderData,
 			"provider_diagnostic":  rawDiagnostic,
 			"thought_blocks":       rawThoughtBlocks,
 			"thoughts_token_count": 4,
@@ -144,6 +146,8 @@ func TestLLMAdapter_CompleteUsesTypedChatBoundary(t *testing.T) {
 	assert.Equal(t, 5, response.Usage.TotalTokens)
 	assert.Equal(t, 4, response.Diagnostics["thoughts_token_count"])
 	assert.Equal(t, rawDiagnostic, response.Diagnostics["provider_diagnostic"])
+	assert.Equal(t, "opaque", response.Message.ProviderData["openai-codex"].([]any)[0].(map[string]any)["encrypted_content"])
+	assert.NotContains(t, response.Diagnostics, "provider_data")
 	thoughtBlocks := response.Diagnostics["thought_blocks"].([]core.ContentBlock)
 	require.Len(t, thoughtBlocks, 1)
 	assert.Equal(t, []byte{3, 4}, thoughtBlocks[0].Data)
@@ -151,12 +155,14 @@ func TestLLMAdapter_CompleteUsesTypedChatBoundary(t *testing.T) {
 	rawArguments["range"].(map[string]any)["start"] = 9
 	rawMetadata["signature"].([]byte)[0] = 9
 	rawDiagnostic["nested"].(map[string]any)["value"] = "changed"
+	rawProviderData["openai-codex"].([]any)[0].(map[string]any)["encrypted_content"] = "changed"
 	rawThoughtBlocks[0].Data[0] = 9
 	rawThoughtBlocks[0].Metadata["nested"].(map[string]any)["value"] = "changed"
 	usage.TotalTokens = 99
 	assert.Equal(t, 1, response.Message.ToolCalls[0].Arguments["range"].(map[string]any)["start"])
 	assert.Equal(t, byte(1), response.Message.ToolCalls[0].Metadata["signature"].([]byte)[0])
 	assert.Equal(t, "original", response.Diagnostics["provider_diagnostic"].(map[string]any)["nested"].(map[string]any)["value"])
+	assert.Equal(t, "opaque", response.Message.ProviderData["openai-codex"].([]any)[0].(map[string]any)["encrypted_content"])
 	assert.Equal(t, byte(3), thoughtBlocks[0].Data[0])
 	assert.Equal(t, "original", thoughtBlocks[0].Metadata["nested"].(map[string]any)["value"])
 	assert.Equal(t, 5, response.Usage.TotalTokens)

--- a/pkg/core/llm.go
+++ b/pkg/core/llm.go
@@ -107,10 +107,11 @@ func (cb ContentBlock) String() string {
 // ChatMessage represents a single message in a multi-turn conversation.
 // Used by ToolCallingChatLLM for true native tool-use loops.
 type ChatMessage struct {
-	Role       string          `json:"role"`                  // "system"|"user"|"assistant"|"tool"
-	Content    []ContentBlock  `json:"content"`               // reuse existing multimodal blocks from llm.go
-	ToolCalls  []ToolCall      `json:"tool_calls,omitempty"`  // for assistant messages requesting tool calls
-	ToolResult *ChatToolResult `json:"tool_result,omitempty"` // for tool role messages
+	Role         string          `json:"role"`                    // "system"|"user"|"assistant"|"tool"
+	Content      []ContentBlock  `json:"content"`                 // reuse existing multimodal blocks from llm.go
+	ToolCalls    []ToolCall      `json:"tool_calls,omitempty"`    // for assistant messages requesting tool calls
+	ToolResult   *ChatToolResult `json:"tool_result,omitempty"`   // for tool role messages
+	ProviderData map[string]any  `json:"provider_data,omitempty"` // opaque continuation state owned by a provider
 }
 
 // ChatToolResult carries the result of a single tool execution in a chat message.

--- a/pkg/llms/factory.go
+++ b/pkg/llms/factory.go
@@ -86,6 +86,10 @@ func ensureRegistryInitialized() error {
 			registryInitErr = fmt.Errorf("failed to register openai provider: %w", err)
 			return
 		}
+		if err := registry.RegisterProvider("openai-codex", OpenAICodexProviderFactory); err != nil {
+			registryInitErr = fmt.Errorf("failed to register openai-codex provider: %w", err)
+			return
+		}
 		if err := registry.RegisterProvider("litellm", LiteLLMProviderFactory); err != nil {
 			registryInitErr = fmt.Errorf("failed to register litellm provider: %w", err)
 			return

--- a/pkg/llms/oauth/http.go
+++ b/pkg/llms/oauth/http.go
@@ -1,5 +1,22 @@
 package oauth
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+)
 
-var httpPost = http.Post
+var (
+	httpPost = http.Post
+	httpDo   = http.DefaultClient.Do
+)
+
+func postFormContext(ctx context.Context, endpoint string, values url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return httpDo(req)
+}

--- a/pkg/llms/oauth/login.go
+++ b/pkg/llms/oauth/login.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -12,9 +13,10 @@ import (
 
 var (
 	pkceGenerator                    = GeneratePKCE
+	oauthStateGenerator              = GenerateState
 	anthropicAuthURL                 = GetAuthorizationURL
 	anthropicCodeExchanger           = ExchangeCode
-	openAIAuthURL                    = GetOpenAIAuthorizationURL
+	openAIAuthURL                    = GetOpenAIAuthorizationURLWithState
 	openAICodeExchanger              = ExchangeOpenAICode
 	browserOpener                    = openBrowser
 	currentGOOS                      = runtime.GOOS
@@ -68,6 +70,20 @@ func LoginAnthropic() (*TokenResponse, error) {
 
 // extractCode extracts the authorization code from various input formats.
 // Supports: bare code, code#state, and full URL with code parameter.
+func extractCodeAndState(input string) (code, state string) {
+	if parsed, err := url.Parse(input); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Query().Get("code"), parsed.Query().Get("state")
+	}
+	if strings.Contains(input, "#") {
+		parts := strings.SplitN(input, "#", 2)
+		return parts[0], parts[1]
+	}
+	if values, err := url.ParseQuery(input); err == nil && values.Has("code") {
+		return values.Get("code"), values.Get("state")
+	}
+	return input, ""
+}
+
 func extractCode(input string) string {
 	// If it contains #, take the part before it
 	if idx := strings.Index(input, "#"); idx != -1 {
@@ -93,14 +109,19 @@ func extractCode(input string) string {
 // LoginOpenAI performs interactive OAuth login for ChatGPT Plus/Pro subscriptions.
 // It opens a browser for authentication and returns the access token.
 func LoginOpenAI() (*OpenAITokenResponse, error) {
-	// Generate PKCE
+	// Generate independent PKCE and CSRF values. The verifier must never be
+	// placed in the authorization URL or browser history.
 	verifier, challenge, err := pkceGenerator()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate PKCE: %w", err)
 	}
+	state, err := oauthStateGenerator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OAuth state: %w", err)
+	}
 
 	// Get authorization URL
-	authURL := openAIAuthURL(verifier, challenge)
+	authURL := openAIAuthURL(challenge, state)
 
 	// Open browser
 	fmt.Println("Opening browser for OpenAI authentication...")
@@ -114,10 +135,13 @@ func LoginOpenAI() (*OpenAITokenResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read input: %w", err)
 	}
-	code := strings.TrimSpace(input)
-
-	// Extract code if user pasted full URL
-	code = extractCode(code)
+	code, returnedState := extractCodeAndState(strings.TrimSpace(input))
+	if returnedState != state {
+		return nil, fmt.Errorf("OpenAI OAuth state mismatch")
+	}
+	if code == "" {
+		return nil, fmt.Errorf("OpenAI OAuth callback did not include a code")
+	}
 
 	// Exchange for token
 	fmt.Println("Exchanging code for token...")

--- a/pkg/llms/oauth/oauth_test.go
+++ b/pkg/llms/oauth/oauth_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -30,7 +31,9 @@ func withOAuthSeams(t *testing.T) {
 
 	origRandRead := randRead
 	origHTTPPost := httpPost
+	origHTTPDo := httpDo
 	origPKCEGenerator := pkceGenerator
+	origStateGenerator := oauthStateGenerator
 	origAnthropicAuthURL := anthropicAuthURL
 	origAnthropicExchanger := anthropicCodeExchanger
 	origOpenAIAuthURL := openAIAuthURL
@@ -44,7 +47,9 @@ func withOAuthSeams(t *testing.T) {
 	t.Cleanup(func() {
 		randRead = origRandRead
 		httpPost = origHTTPPost
+		httpDo = origHTTPDo
 		pkceGenerator = origPKCEGenerator
+		oauthStateGenerator = origStateGenerator
 		anthropicAuthURL = origAnthropicAuthURL
 		anthropicCodeExchanger = origAnthropicExchanger
 		openAIAuthURL = origOpenAIAuthURL
@@ -153,7 +158,12 @@ func TestGetOpenAIAuthorizationURL(t *testing.T) {
 	assert.Equal(t, OpenAIScopes, u.Query().Get("scope"))
 	assert.Equal(t, "challenge", u.Query().Get("code_challenge"))
 	assert.Equal(t, "S256", u.Query().Get("code_challenge_method"))
-	assert.Equal(t, "verifier", u.Query().Get("state"))
+	assert.Equal(t, "challenge", u.Query().Get("state"))
+
+	secure, err := url.Parse(GetOpenAIAuthorizationURLWithState("challenge", "independent-state"))
+	require.NoError(t, err)
+	assert.Equal(t, "independent-state", secure.Query().Get("state"))
+	assert.NotEqual(t, "verifier", secure.Query().Get("state"))
 }
 
 func TestExchangeCode(t *testing.T) {
@@ -217,6 +227,19 @@ func TestExchangeCode(t *testing.T) {
 	})
 }
 
+func TestOpenAITokenContextCancellation(t *testing.T) {
+	withOAuthSeams(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	httpDo = func(req *http.Request) (*http.Response, error) {
+		return nil, req.Context().Err()
+	}
+
+	response, err := RefreshOpenAIAccessTokenContext(ctx, "refresh-token")
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, response)
+}
+
 func TestRefreshAccessToken(t *testing.T) {
 	withOAuthSeams(t)
 
@@ -277,17 +300,19 @@ func TestExchangeOpenAICode(t *testing.T) {
 	withOAuthSeams(t)
 
 	t.Run("success", func(t *testing.T) {
-		httpPost = func(url, contentType string, body io.Reader) (*http.Response, error) {
-			assert.Equal(t, OpenAITokenURL, url)
-			assert.Equal(t, "application/json", contentType)
+		httpPost = func(endpoint, contentType string, body io.Reader) (*http.Response, error) {
+			assert.Equal(t, OpenAITokenURL, endpoint)
+			assert.Equal(t, "application/x-www-form-urlencoded", contentType)
 
-			var payload map[string]string
-			require.NoError(t, json.NewDecoder(body).Decode(&payload))
-			assert.Equal(t, "authorization_code", payload["grant_type"])
-			assert.Equal(t, OpenAIClientID, payload["client_id"])
-			assert.Equal(t, "auth-code", payload["code"])
-			assert.Equal(t, OpenAIRedirectURI, payload["redirect_uri"])
-			assert.Equal(t, "verifier", payload["code_verifier"])
+			encoded, err := io.ReadAll(body)
+			require.NoError(t, err)
+			payload, err := url.ParseQuery(string(encoded))
+			require.NoError(t, err)
+			assert.Equal(t, "authorization_code", payload.Get("grant_type"))
+			assert.Equal(t, OpenAIClientID, payload.Get("client_id"))
+			assert.Equal(t, "auth-code", payload.Get("code"))
+			assert.Equal(t, OpenAIRedirectURI, payload.Get("redirect_uri"))
+			assert.Equal(t, "verifier", payload.Get("code_verifier"))
 
 			return httpResponse(http.StatusOK, `{"access_token":"access","refresh_token":"refresh","expires_in":3600,"token_type":"Bearer","scope":"openid"}`), nil
 		}
@@ -337,15 +362,17 @@ func TestRefreshOpenAIAccessToken(t *testing.T) {
 	withOAuthSeams(t)
 
 	t.Run("success", func(t *testing.T) {
-		httpPost = func(url, contentType string, body io.Reader) (*http.Response, error) {
-			assert.Equal(t, OpenAITokenURL, url)
-			assert.Equal(t, "application/json", contentType)
+		httpPost = func(endpoint, contentType string, body io.Reader) (*http.Response, error) {
+			assert.Equal(t, OpenAITokenURL, endpoint)
+			assert.Equal(t, "application/x-www-form-urlencoded", contentType)
 
-			var payload map[string]string
-			require.NoError(t, json.NewDecoder(body).Decode(&payload))
-			assert.Equal(t, "refresh_token", payload["grant_type"])
-			assert.Equal(t, OpenAIClientID, payload["client_id"])
-			assert.Equal(t, "refresh-token", payload["refresh_token"])
+			encoded, err := io.ReadAll(body)
+			require.NoError(t, err)
+			payload, err := url.ParseQuery(string(encoded))
+			require.NoError(t, err)
+			assert.Equal(t, "refresh_token", payload.Get("grant_type"))
+			assert.Equal(t, OpenAIClientID, payload.Get("client_id"))
+			assert.Equal(t, "refresh-token", payload.Get("refresh_token"))
 
 			return httpResponse(http.StatusOK, `{"access_token":"access","refresh_token":"refresh","expires_in":3600,"token_type":"Bearer","scope":"openid"}`), nil
 		}
@@ -447,15 +474,28 @@ func TestLoginAnthropic(t *testing.T) {
 func TestLoginOpenAI(t *testing.T) {
 	withOAuthSeams(t)
 
-	t.Run("exchange failure", func(t *testing.T) {
+	configure := func(input string) {
 		pkceGenerator = func() (string, string, error) { return "verifier", "challenge", nil }
-		openAIAuthURL = func(verifier, challenge string) string {
-			assert.Equal(t, "verifier", verifier)
+		oauthStateGenerator = func() (string, error) { return "csrf-state", nil }
+		openAIAuthURL = func(challenge, state string) string {
 			assert.Equal(t, "challenge", challenge)
+			assert.Equal(t, "csrf-state", state)
 			return "https://example.com/authorize"
 		}
 		browserOpener = func(string) {}
-		loginInputReader = strings.NewReader("code123\n")
+		loginInputReader = strings.NewReader(input + "\n")
+	}
+
+	t.Run("state mismatch", func(t *testing.T) {
+		configure("http://localhost/callback?code=code123&state=wrong")
+		resp, err := LoginOpenAI()
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Contains(t, err.Error(), "state mismatch")
+	})
+
+	t.Run("exchange failure", func(t *testing.T) {
+		configure("code123#csrf-state")
 		openAICodeExchanger = func(code, verifier string) (*OpenAITokenResponse, error) {
 			assert.Equal(t, "code123", code)
 			assert.Equal(t, "verifier", verifier)
@@ -469,25 +509,11 @@ func TestLoginOpenAI(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		var openedURL string
-		pkceGenerator = func() (string, string, error) { return "verifier", "challenge", nil }
-		openAIAuthURL = func(verifier, challenge string) string {
-			assert.Equal(t, "verifier", verifier)
-			assert.Equal(t, "challenge", challenge)
-			return "https://example.com/openai"
-		}
-		browserOpener = func(url string) { openedURL = url }
-		loginInputReader = strings.NewReader("http://localhost/callback?code=xyz789\n")
+		configure("http://localhost/callback?code=xyz789&state=csrf-state")
 		openAICodeExchanger = func(code, verifier string) (*OpenAITokenResponse, error) {
 			assert.Equal(t, "xyz789", code)
 			assert.Equal(t, "verifier", verifier)
-			return &OpenAITokenResponse{
-				AccessToken:  "access",
-				RefreshToken: "refresh",
-				ExpiresIn:    3600,
-				TokenType:    "Bearer",
-				Scope:        "openid",
-			}, nil
+			return &OpenAITokenResponse{AccessToken: "access", RefreshToken: "refresh", ExpiresIn: 3600}, nil
 		}
 
 		resp, err := LoginOpenAI()
@@ -495,7 +521,6 @@ func TestLoginOpenAI(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Equal(t, "access", resp.AccessToken)
 		assert.Equal(t, "refresh", resp.RefreshToken)
-		assert.Equal(t, "https://example.com/openai", openedURL)
 	})
 }
 

--- a/pkg/llms/oauth/openai.go
+++ b/pkg/llms/oauth/openai.go
@@ -1,11 +1,12 @@
 package oauth
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -22,6 +23,7 @@ const (
 // OpenAITokenResponse represents the OAuth token response from OpenAI.
 type OpenAITokenResponse struct {
 	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token,omitempty"`
 	RefreshToken string `json:"refresh_token"`
 	ExpiresIn    int    `json:"expires_in"`
 	TokenType    string `json:"token_type"`
@@ -29,35 +31,42 @@ type OpenAITokenResponse struct {
 }
 
 // GetOpenAIAuthorizationURL returns the URL for user to authorize with OpenAI.
-func GetOpenAIAuthorizationURL(verifier, challenge string) string {
+// Deprecated: use GetOpenAIAuthorizationURLWithState with an independently
+// generated state value. The challenge is used as a non-secret compatibility
+// state here so this legacy API never exposes the PKCE verifier.
+func GetOpenAIAuthorizationURL(_verifier, challenge string) string {
+	return GetOpenAIAuthorizationURLWithState(challenge, challenge)
+}
+
+// GetOpenAIAuthorizationURLWithState returns an OpenAI Codex authorization URL.
+// State must be independently generated and validated by the caller.
+func GetOpenAIAuthorizationURLWithState(challenge, state string) string {
 	params := url.Values{
-		"response_type":         {"code"},
-		"client_id":             {OpenAIClientID},
-		"redirect_uri":          {OpenAIRedirectURI},
-		"scope":                 {OpenAIScopes},
-		"code_challenge":        {challenge},
-		"code_challenge_method": {"S256"},
-		"state":                 {verifier},
+		"response_type":              {"code"},
+		"client_id":                  {OpenAIClientID},
+		"redirect_uri":               {OpenAIRedirectURI},
+		"scope":                      {OpenAIScopes},
+		"code_challenge":             {challenge},
+		"code_challenge_method":      {"S256"},
+		"state":                      {state},
+		"id_token_add_organizations": {"true"},
+		"codex_cli_simplified_flow":  {"true"},
+		"originator":                 {"dspy-go"},
 	}
 	return OpenAIAuthorizationURL + "?" + params.Encode()
 }
 
 // ExchangeOpenAICode exchanges an authorization code for tokens.
 func ExchangeOpenAICode(code, verifier string) (*OpenAITokenResponse, error) {
-	payload := map[string]string{
-		"grant_type":    "authorization_code",
-		"client_id":     OpenAIClientID,
-		"code":          code,
-		"redirect_uri":  OpenAIRedirectURI,
-		"code_verifier": verifier,
+	payload := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {OpenAIClientID},
+		"code":          {code},
+		"redirect_uri":  {OpenAIRedirectURI},
+		"code_verifier": {verifier},
 	}
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal payload: %w", err)
-	}
-
-	resp, err := httpPost(OpenAITokenURL, "application/json", bytes.NewReader(body))
+	resp, err := httpPost(OpenAITokenURL, "application/x-www-form-urlencoded", strings.NewReader(payload.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code: %w", err)
 	}
@@ -75,20 +84,48 @@ func ExchangeOpenAICode(code, verifier string) (*OpenAITokenResponse, error) {
 	return &result, nil
 }
 
+// ExchangeOpenAICodeContext exchanges an authorization code with cancellation.
+func ExchangeOpenAICodeContext(ctx context.Context, code, verifier string) (*OpenAITokenResponse, error) {
+	payload := url.Values{
+		"grant_type": {"authorization_code"}, "client_id": {OpenAIClientID},
+		"code": {code}, "redirect_uri": {OpenAIRedirectURI}, "code_verifier": {verifier},
+	}
+	return postOpenAITokenContext(ctx, payload, "exchange")
+}
+
+// RefreshOpenAIAccessTokenContext refreshes an access token with cancellation.
+func RefreshOpenAIAccessTokenContext(ctx context.Context, refreshToken string) (*OpenAITokenResponse, error) {
+	payload := url.Values{
+		"grant_type": {"refresh_token"}, "client_id": {OpenAIClientID}, "refresh_token": {refreshToken},
+	}
+	return postOpenAITokenContext(ctx, payload, "refresh")
+}
+
+func postOpenAITokenContext(ctx context.Context, payload url.Values, action string) (*OpenAITokenResponse, error) {
+	resp, err := postFormContext(ctx, OpenAITokenURL, payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to %s token: %w", action, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token %s failed: %s", action, resp.Status)
+	}
+	var result OpenAITokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, nil
+}
+
 // RefreshOpenAIAccessToken refreshes an expired access token.
 func RefreshOpenAIAccessToken(refreshToken string) (*OpenAITokenResponse, error) {
-	payload := map[string]string{
-		"grant_type":    "refresh_token",
-		"client_id":     OpenAIClientID,
-		"refresh_token": refreshToken,
+	payload := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {OpenAIClientID},
+		"refresh_token": {refreshToken},
 	}
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal payload: %w", err)
-	}
-
-	resp, err := httpPost(OpenAITokenURL, "application/json", bytes.NewReader(body))
+	resp, err := httpPost(OpenAITokenURL, "application/x-www-form-urlencoded", strings.NewReader(payload.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh token: %w", err)
 	}

--- a/pkg/llms/oauth/pkce.go
+++ b/pkg/llms/oauth/pkce.go
@@ -10,6 +10,15 @@ var randRead = rand.Read
 
 // GeneratePKCE generates a PKCE verifier and challenge pair.
 // The verifier is a random string, and the challenge is its SHA256 hash.
+// GenerateState returns an unpredictable OAuth CSRF state value.
+func GenerateState() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := randRead(bytes); err != nil {
+		return "", err
+	}
+	return base64URLEncode(bytes), nil
+}
+
 func GeneratePKCE() (verifier, challenge string, err error) {
 	// Generate 32 random bytes for verifier
 	bytes := make([]byte, 32)

--- a/pkg/llms/openai.go
+++ b/pkg/llms/openai.go
@@ -40,12 +40,6 @@ type OpenAIConfig struct {
 	httpClient *http.Client
 }
 
-// isOpenAIOAuthToken checks if the token is an OAuth token from ChatGPT Plus/Pro subscription.
-func isOpenAIOAuthToken(token string) bool {
-	// OpenAI OAuth tokens from auth.openai.com typically start with specific prefixes
-	return strings.HasPrefix(token, "sess-") || strings.HasPrefix(token, "oat-")
-}
-
 // NewOpenAILLM creates a new OpenAILLM instance with functional options.
 func NewOpenAILLM(modelID core.ModelID, opts ...OpenAIOption) (*OpenAILLM, error) {
 	config := &OpenAIConfig{
@@ -59,11 +53,7 @@ func NewOpenAILLM(modelID core.ModelID, opts ...OpenAIOption) (*OpenAILLM, error
 		opt(config)
 	}
 
-	// Environment variable fallback for API key
-	// Priority: OPENAI_OAUTH_TOKEN > config.apiKey > OPENAI_API_KEY
-	if config.apiKey == "" {
-		config.apiKey = os.Getenv("OPENAI_OAUTH_TOKEN")
-	}
+	// Explicit configuration takes precedence over the environment.
 	if config.apiKey == "" {
 		config.apiKey = os.Getenv("OPENAI_API_KEY")
 	}
@@ -71,8 +61,8 @@ func NewOpenAILLM(modelID core.ModelID, opts ...OpenAIOption) (*OpenAILLM, error
 	// API key validation - required for official OpenAI API endpoint
 	if config.apiKey == "" && config.baseURL == "https://api.openai.com" {
 		return nil, errors.WithFields(
-			errors.New(errors.InvalidInput, "OpenAI API key or OAuth token required"),
-			errors.Fields{"env_vars": "OPENAI_API_KEY or OPENAI_OAUTH_TOKEN"})
+			errors.New(errors.InvalidInput, "OpenAI API key required"),
+			errors.Fields{"env_var": "OPENAI_API_KEY"})
 	}
 
 	// Build endpoint configuration
@@ -87,11 +77,6 @@ func NewOpenAILLM(modelID core.ModelID, opts ...OpenAIOption) (*OpenAILLM, error
 	if config.apiKey != "" {
 		endpointCfg.Headers["Authorization"] = "Bearer " + config.apiKey
 
-		// Add OAuth-specific headers for ChatGPT Plus/Pro subscriptions
-		if isOpenAIOAuthToken(config.apiKey) {
-			endpointCfg.Headers["openai-beta"] = "assistants=v2"
-			endpointCfg.Headers["x-openai-client"] = "dspy-go"
-		}
 	}
 	endpointCfg.Headers["Content-Type"] = "application/json"
 
@@ -163,11 +148,8 @@ func NewOpenAI(modelID core.ModelID, apiKey string) (*OpenAILLM, error) {
 func NewOpenAILLMFromConfig(ctx context.Context, config core.ProviderConfig, modelID core.ModelID) (*OpenAILLM, error) {
 	opts := []OpenAIOption{}
 
-	// Priority: OPENAI_OAUTH_TOKEN > config.APIKey > OPENAI_API_KEY
-	apiKey := os.Getenv("OPENAI_OAUTH_TOKEN")
-	if apiKey == "" {
-		apiKey = config.APIKey
-	}
+	// Explicit configuration takes precedence over the environment.
+	apiKey := config.APIKey
 	if apiKey == "" {
 		apiKey = os.Getenv("OPENAI_API_KEY")
 	}

--- a/pkg/llms/openai_codex.go
+++ b/pkg/llms/openai_codex.go
@@ -1,0 +1,763 @@
+package llms
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/errors"
+	"github.com/XiaoConstantine/dspy-go/pkg/utils"
+)
+
+const defaultOpenAICodexBaseURL = "https://chatgpt.com/backend-api"
+
+// OpenAICodexCredentials are resolved before every request so callers can
+// refresh short-lived ChatGPT subscription credentials without rebuilding the LLM.
+type OpenAICodexCredentials struct {
+	AccessToken string
+	AccountID   string
+}
+
+// OpenAICodexCredentialResolver returns current ChatGPT subscription credentials.
+// rejectedAccessToken is non-empty after an authentication failure. The owner
+// should refresh only when storage still contains that token; another concurrent
+// request may already have rotated it.
+type OpenAICodexCredentialResolver func(ctx context.Context, rejectedAccessToken string) (OpenAICodexCredentials, error)
+
+type OpenAICodexOption func(*openAICodexConfig)
+
+type openAICodexConfig struct {
+	baseURL            string
+	timeout            time.Duration
+	headers            map[string]string
+	httpClient         *http.Client
+	credentialResolver OpenAICodexCredentialResolver
+	originator         string
+	reasoningEffort    string
+}
+
+// OpenAICodexLLM implements the ChatGPT subscription Codex Responses protocol.
+type OpenAICodexLLM struct {
+	*core.BaseLLM
+	resolver        OpenAICodexCredentialResolver
+	headers         map[string]string
+	originator      string
+	reasoningEffort string
+	httpClient      *http.Client
+}
+
+func WithOpenAICodexCredentials(resolver OpenAICodexCredentialResolver) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.credentialResolver = resolver }
+}
+
+func WithOpenAICodexBaseURL(baseURL string) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.baseURL = strings.TrimRight(baseURL, "/") }
+}
+
+func WithOpenAICodexHTTPClient(client *http.Client) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.httpClient = client }
+}
+
+func WithOpenAICodexTimeout(timeout time.Duration) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.timeout = timeout }
+}
+
+func WithOpenAICodexHeader(name, value string) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.headers[name] = value }
+}
+
+func WithOpenAICodexOriginator(originator string) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.originator = originator }
+}
+
+func WithOpenAICodexReasoningEffort(effort string) OpenAICodexOption {
+	return func(c *openAICodexConfig) { c.reasoningEffort = effort }
+}
+
+func NewOpenAICodexLLM(modelID core.ModelID, opts ...OpenAICodexOption) (*OpenAICodexLLM, error) {
+	config := openAICodexConfig{
+		baseURL:    defaultOpenAICodexBaseURL,
+		timeout:    120 * time.Second,
+		headers:    map[string]string{},
+		originator: "dspy-go",
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	if config.credentialResolver == nil {
+		return nil, errors.New(errors.InvalidInput, "OpenAI Codex credential resolver is required")
+	}
+	endpoint := &core.EndpointConfig{
+		BaseURL:    config.baseURL,
+		Path:       "/codex/responses",
+		TimeoutSec: int(config.timeout.Seconds()),
+	}
+	base := core.NewBaseLLM("openai-codex", modelID, []core.Capability{
+		core.CapabilityCompletion, core.CapabilityChat, core.CapabilityJSON, core.CapabilityToolCalling,
+	}, endpoint)
+	client := config.httpClient
+	if client == nil {
+		client = base.GetHTTPClient()
+	}
+	return &OpenAICodexLLM{
+		BaseLLM:         base,
+		resolver:        config.credentialResolver,
+		headers:         cloneStringMap(config.headers),
+		originator:      config.originator,
+		reasoningEffort: config.reasoningEffort,
+		httpClient:      client,
+	}, nil
+}
+
+func NewOpenAICodexLLMFromConfig(_ context.Context, config core.ProviderConfig, modelID core.ModelID) (*OpenAICodexLLM, error) {
+	token := strings.TrimSpace(config.APIKey)
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv("OPENAI_OAUTH_TOKEN"))
+	}
+	if token == "" {
+		return nil, errors.New(errors.InvalidInput, "OpenAI Codex OAuth access token is required")
+	}
+	accountID := ""
+	if config.Endpoint != nil {
+		accountID = headerValue(config.Endpoint.Headers, "ChatGPT-Account-ID")
+	}
+	if accountID == "" {
+		accountID, _ = config.Params["account_id"].(string)
+		accountID = strings.TrimSpace(accountID)
+	}
+	if accountID == "" {
+		idToken, _ := config.Params["id_token"].(string)
+		if idToken == "" {
+			idToken = strings.TrimSpace(os.Getenv("OPENAI_ID_TOKEN"))
+		}
+		if idToken != "" {
+			accountID, _ = OpenAICodexAccountIDFromToken(idToken)
+		}
+	}
+	if accountID == "" {
+		var err error
+		accountID, err = OpenAICodexAccountID(token)
+		if err != nil {
+			return nil, errors.Wrap(err, errors.InvalidInput, "resolve OpenAI Codex account id from account_id, id_token, or access token")
+		}
+	}
+	credentials := OpenAICodexCredentials{AccessToken: token, AccountID: accountID}
+	opts := []OpenAICodexOption{WithOpenAICodexCredentials(func(context.Context, string) (OpenAICodexCredentials, error) {
+		return credentials, nil
+	})}
+	baseURL := config.BaseURL
+	if config.Endpoint != nil && config.Endpoint.BaseURL != "" {
+		baseURL = config.Endpoint.BaseURL
+	}
+	if baseURL != "" {
+		opts = append(opts, WithOpenAICodexBaseURL(baseURL))
+	}
+	if config.Endpoint != nil {
+		if config.Endpoint.TimeoutSec > 0 {
+			opts = append(opts, WithOpenAICodexTimeout(time.Duration(config.Endpoint.TimeoutSec)*time.Second))
+		}
+		for name, value := range config.Endpoint.Headers {
+			if !strings.EqualFold(name, "Authorization") && !strings.EqualFold(name, "ChatGPT-Account-ID") {
+				opts = append(opts, WithOpenAICodexHeader(name, value))
+			}
+		}
+	}
+	return NewOpenAICodexLLM(modelID, opts...)
+}
+
+func OpenAICodexProviderFactory(ctx context.Context, config core.ProviderConfig, modelID core.ModelID) (core.LLM, error) {
+	return NewOpenAICodexLLMFromConfig(ctx, config, modelID)
+}
+
+// OpenAICodexAccountID extracts the ChatGPT account identifier from an OAuth access JWT.
+// The token signature is verified by the server when the token is used; this only reads claims.
+func OpenAICodexAccountID(accessToken string) (string, error) {
+	return OpenAICodexAccountIDFromToken(accessToken)
+}
+
+// OpenAICodexAccountIDFromToken extracts the ChatGPT account identifier from
+// an OpenAI ID or access JWT without verifying its signature.
+func OpenAICodexAccountIDFromToken(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", errors.New(errors.InvalidInput, "OpenAI Codex access token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", errors.Wrap(err, errors.InvalidInput, "decode OpenAI Codex access token")
+	}
+	var claims struct {
+		Auth struct {
+			AccountID string `json:"chatgpt_account_id"`
+		} `json:"https://api.openai.com/auth"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", errors.Wrap(err, errors.InvalidInput, "decode OpenAI Codex access token claims")
+	}
+	if strings.TrimSpace(claims.Auth.AccountID) == "" {
+		return "", errors.New(errors.InvalidInput, "OpenAI Codex access token is missing chatgpt_account_id")
+	}
+	return strings.TrimSpace(claims.Auth.AccountID), nil
+}
+
+func (o *OpenAICodexLLM) Generate(ctx context.Context, prompt string, options ...core.GenerateOption) (*core.LLMResponse, error) {
+	result, err := o.generate(ctx, []core.ChatMessage{{Role: "user", Content: []core.ContentBlock{core.NewTextBlock(prompt)}}}, nil, options...)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.providerData) > 0 {
+		result.metadata["provider_data"] = result.providerData
+	}
+	return &core.LLMResponse{Content: result.content, Usage: result.usage, Metadata: result.metadata}, nil
+}
+
+func (o *OpenAICodexLLM) GenerateWithTools(ctx context.Context, messages []core.ChatMessage, tools []map[string]any, options ...core.GenerateOption) (map[string]any, error) {
+	if len(tools) == 0 {
+		return nil, errors.New(errors.InvalidInput, "at least one tool schema is required")
+	}
+	result, err := o.generate(ctx, messages, tools, options...)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{"_usage": result.usage}
+	if len(result.providerData) > 0 {
+		out["provider_data"] = result.providerData
+	}
+	if result.content != "" {
+		out["content"] = result.content
+	}
+	if len(result.toolCalls) > 0 {
+		out["tool_calls"] = result.toolCalls
+		out["function_call"] = map[string]any{"name": result.toolCalls[0].Name, "arguments": result.toolCalls[0].Arguments}
+	}
+	if result.content == "" && len(result.toolCalls) == 0 {
+		out["content"] = "No content or function call received from model"
+	}
+	return out, nil
+}
+
+func (o *OpenAICodexLLM) GenerateWithFunctions(ctx context.Context, prompt string, functions []map[string]any, options ...core.GenerateOption) (map[string]any, error) {
+	return o.GenerateWithTools(ctx, []core.ChatMessage{{Role: "user", Content: []core.ContentBlock{core.NewTextBlock(prompt)}}}, functions, options...)
+}
+
+func (o *OpenAICodexLLM) GenerateWithJSON(ctx context.Context, prompt string, options ...core.GenerateOption) (map[string]any, error) {
+	response, err := o.Generate(ctx, prompt+"\n\nReturn only a valid JSON object.", options...)
+	if err != nil {
+		return nil, err
+	}
+	return utils.ParseJSONResponse(response.Content)
+}
+
+func (o *OpenAICodexLLM) GenerateWithContent(ctx context.Context, content []core.ContentBlock, options ...core.GenerateOption) (*core.LLMResponse, error) {
+	return o.Generate(ctx, flattenCoreChatMessageContent(content), options...)
+}
+
+func (o *OpenAICodexLLM) StreamGenerate(ctx context.Context, prompt string, options ...core.GenerateOption) (*core.StreamResponse, error) {
+	streamCtx, cancel := context.WithCancel(ctx)
+	chunks := make(chan core.StreamChunk, 1)
+	go func() {
+		defer close(chunks)
+		response, err := o.Generate(streamCtx, prompt, options...)
+		if err != nil {
+			chunks <- core.StreamChunk{Done: true, Error: err}
+			return
+		}
+		chunks <- core.StreamChunk{Content: response.Content, Done: true, Usage: response.Usage}
+	}()
+	return &core.StreamResponse{ChunkChannel: chunks, Cancel: cancel}, nil
+}
+
+func (o *OpenAICodexLLM) StreamGenerateWithContent(ctx context.Context, content []core.ContentBlock, options ...core.GenerateOption) (*core.StreamResponse, error) {
+	return o.StreamGenerate(ctx, flattenCoreChatMessageContent(content), options...)
+}
+
+func (o *OpenAICodexLLM) CreateEmbedding(context.Context, string, ...core.EmbeddingOption) (*core.EmbeddingResult, error) {
+	return nil, errors.New(errors.UnsupportedOperation, "OpenAI Codex subscriptions do not provide embeddings")
+}
+
+func (o *OpenAICodexLLM) CreateEmbeddings(context.Context, []string, ...core.EmbeddingOption) (*core.BatchEmbeddingResult, error) {
+	return nil, errors.New(errors.UnsupportedOperation, "OpenAI Codex subscriptions do not provide embeddings")
+}
+
+type openAICodexResult struct {
+	content      string
+	toolCalls    []core.ToolCall
+	usage        *core.TokenInfo
+	metadata     map[string]any
+	providerData map[string]any
+}
+
+type codexToolBuilder struct {
+	ID        string
+	Name      string
+	Arguments strings.Builder
+}
+
+func (o *OpenAICodexLLM) generate(ctx context.Context, messages []core.ChatMessage, tools []map[string]any, options ...core.GenerateOption) (*openAICodexResult, error) {
+	payload, err := o.requestPayload(messages, tools, options...)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.InvalidInput, "encode OpenAI Codex request")
+	}
+
+	rejectedAccessToken := ""
+	for attempt := 0; attempt < 2; attempt++ {
+		credentials, err := o.resolver(ctx, rejectedAccessToken)
+		if err != nil {
+			return nil, errors.Wrap(err, errors.Unknown, "resolve OpenAI Codex credentials")
+		}
+		if strings.TrimSpace(credentials.AccessToken) == "" || strings.TrimSpace(credentials.AccountID) == "" {
+			return nil, errors.New(errors.InvalidInput, "OpenAI Codex credentials require access token and account id")
+		}
+		resp, err := o.sendRequest(ctx, body, credentials)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusUnauthorized && attempt == 0 {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+			resp.Body.Close()
+			rejectedAccessToken = credentials.AccessToken
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			limited, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+			return nil, errors.WithFields(errors.New(errors.Unknown, fmt.Sprintf("OpenAI Codex request failed: %s", resp.Status)), errors.Fields{"status_code": resp.StatusCode, "body": strings.TrimSpace(string(limited))})
+		}
+		return parseOpenAICodexSSE(resp.Body)
+	}
+	return nil, errors.New(errors.Unknown, "OpenAI Codex authentication failed")
+}
+
+func (o *OpenAICodexLLM) sendRequest(ctx context.Context, body []byte, credentials OpenAICodexCredentials) (*http.Response, error) {
+	endpoint := o.GetEndpointConfig()
+	url := resolveOpenAICodexResponsesURL(endpoint.BaseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, errors.Wrap(err, errors.Unknown, "create OpenAI Codex request")
+	}
+	for name, value := range o.headers {
+		req.Header.Set(name, value)
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(credentials.AccessToken))
+	req.Header.Set("ChatGPT-Account-ID", strings.TrimSpace(credentials.AccountID))
+	req.Header.Set("OpenAI-Beta", "responses=experimental")
+	req.Header.Set("Originator", o.originator)
+	req.Header.Set("User-Agent", "dspy-go")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := o.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.Unknown, "send OpenAI Codex request")
+	}
+	return resp, nil
+}
+
+func resolveOpenAICodexResponsesURL(baseURL string) string {
+	normalized := strings.TrimRight(baseURL, "/")
+	switch {
+	case strings.HasSuffix(normalized, "/codex/responses"):
+		return normalized
+	case strings.HasSuffix(normalized, "/codex"):
+		return normalized + "/responses"
+	default:
+		return normalized + "/codex/responses"
+	}
+}
+
+func (o *OpenAICodexLLM) requestPayload(messages []core.ChatMessage, tools []map[string]any, options ...core.GenerateOption) (map[string]any, error) {
+	// The subscription Codex endpoint currently rejects public Responses
+	// sampling and max-output parameters. Keep options in the interface for
+	// compatibility, but do not forward unsupported fields.
+	_ = options
+	instructions := make([]string, 0, 1)
+	input := make([]map[string]any, 0, len(messages))
+	for _, message := range messages {
+		text := flattenCoreChatMessageContent(message.Content)
+		switch message.Role {
+		case "system", "developer":
+			if text != "" {
+				instructions = append(instructions, text)
+			}
+		case "user":
+			input = append(input, map[string]any{"role": "user", "content": []map[string]any{{"type": "input_text", "text": text}}})
+		case "assistant":
+			var replayed bool
+			var err error
+			input, replayed, err = appendOpenAICodexProviderData(input, message.ProviderData)
+			if err != nil {
+				return nil, err
+			}
+			if replayed {
+				continue
+			}
+			if text != "" {
+				input = append(input, map[string]any{"type": "message", "role": "assistant", "status": "completed", "content": []map[string]any{{"type": "output_text", "text": text, "annotations": []any{}}}})
+			}
+			for _, call := range message.ToolCalls {
+				arguments, err := json.Marshal(call.Arguments)
+				if err != nil {
+					return nil, err
+				}
+				input = append(input, map[string]any{"type": "function_call", "call_id": call.ID, "name": call.Name, "arguments": string(arguments)})
+			}
+		case "tool":
+			if message.ToolResult != nil {
+				input = append(input, map[string]any{"type": "function_call_output", "call_id": message.ToolResult.ToolCallID, "output": flattenCoreChatMessageContent(message.ToolResult.Content)})
+			}
+		}
+	}
+	if len(instructions) == 0 {
+		instructions = append(instructions, "You are a helpful assistant.")
+	}
+	payload := map[string]any{
+		"model": o.ModelID(), "store": false, "stream": true,
+		"instructions": strings.Join(instructions, "\n\n"), "input": input,
+		"text": map[string]any{"verbosity": "low"}, "include": []string{"reasoning.encrypted_content"},
+		"tool_choice": "auto", "parallel_tool_calls": true,
+	}
+	if o.reasoningEffort != "" {
+		payload["reasoning"] = map[string]any{"effort": o.reasoningEffort, "summary": "auto"}
+	}
+	if len(tools) > 0 {
+		converted := make([]map[string]any, 0, len(tools))
+		for _, tool := range tools {
+			name, _ := tool["name"].(string)
+			if strings.TrimSpace(name) == "" {
+				return nil, errors.New(errors.InvalidInput, "tool schema missing non-empty name")
+			}
+			parameters := tool["parameters"]
+			if parameters == nil {
+				parameters = map[string]any{"type": "object"}
+			}
+			strict, _ := tool["strict"].(bool)
+			converted = append(converted, map[string]any{"type": "function", "name": name, "description": tool["description"], "parameters": parameters, "strict": strict})
+		}
+		payload["tools"] = converted
+	}
+	return payload, nil
+}
+
+func appendOpenAICodexProviderData(input []map[string]any, providerData map[string]any) ([]map[string]any, bool, error) {
+	raw, ok := providerData["openai-codex"]
+	if !ok {
+		return input, false, nil
+	}
+	start := len(input)
+	switch items := raw.(type) {
+	case []map[string]any:
+		for _, item := range items {
+			cloned, err := cloneOpenAICodexContinuationItem(item)
+			if err != nil {
+				return nil, false, err
+			}
+			input = append(input, cloned)
+		}
+	case []any:
+		for _, rawItem := range items {
+			item, ok := rawItem.(map[string]any)
+			if !ok {
+				return nil, false, errors.New(errors.InvalidInput, "OpenAI Codex provider continuation item must be an object")
+			}
+			cloned, err := cloneOpenAICodexContinuationItem(item)
+			if err != nil {
+				return nil, false, err
+			}
+			input = append(input, cloned)
+		}
+	default:
+		return nil, false, errors.New(errors.InvalidInput, "OpenAI Codex provider continuation must be an array")
+	}
+	if len(input) == start {
+		return nil, false, errors.New(errors.InvalidInput, "OpenAI Codex provider continuation must not be empty")
+	}
+	return input, true, nil
+}
+
+func cloneOpenAICodexContinuationItem(item map[string]any) (map[string]any, error) {
+	if item == nil {
+		return nil, errors.New(errors.InvalidInput, "OpenAI Codex provider continuation item must not be null")
+	}
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.InvalidInput, "encode OpenAI Codex provider continuation item")
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		return nil, errors.Wrap(err, errors.InvalidInput, "decode OpenAI Codex provider continuation item")
+	}
+	return cloned, nil
+}
+
+func parseOpenAICodexSSE(reader io.Reader) (*openAICodexResult, error) {
+	result := &openAICodexResult{usage: &core.TokenInfo{}, metadata: map[string]any{}}
+	builders := map[string]*codexToolBuilder{}
+	outputItems := map[int]map[string]any{}
+	terminal := false
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64<<10), 32<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			return nil, errors.Wrap(err, errors.InvalidResponse, "decode OpenAI Codex SSE event")
+		}
+		typeName, _ := event["type"].(string)
+		switch typeName {
+		case "error", "response.failed":
+			return nil, errors.WithFields(errors.New(errors.InvalidResponse, "OpenAI Codex response failed"), errors.Fields{"event": event})
+		case "response.output_text.delta":
+			if delta, ok := event["delta"].(string); ok {
+				result.content += delta
+			}
+		case "response.output_item.added", "response.output_item.done", "response.output_item.completed":
+			item, _ := event["item"].(map[string]any)
+			if item == nil {
+				return nil, errors.New(errors.InvalidResponse, "OpenAI Codex output item event is missing item")
+			}
+			finished := typeName != "response.output_item.added"
+			if item["type"] == "function_call" {
+				key := codexToolKey(item, event)
+				builder := builders[key]
+				if builder == nil {
+					builder = &codexToolBuilder{}
+					builders[key] = builder
+				}
+				updateCodexToolBuilder(builder, item)
+				if finished {
+					item = cloneCodexMap(item)
+					item["call_id"] = builder.ID
+					item["name"] = builder.Name
+					item["arguments"] = builder.Arguments.String()
+					delete(builders, key)
+				}
+			} else if item["type"] == "message" && result.content == "" && finished {
+				result.content = codexMessageText(item)
+			}
+			if finished {
+				index, ok := codexOutputIndex(event)
+				if !ok {
+					return nil, errors.New(errors.InvalidResponse, "OpenAI Codex completed output item is missing output_index")
+				}
+				if existing, exists := outputItems[index]; exists && !sameCodexOutputIdentity(existing, item) {
+					return nil, errors.WithFields(errors.New(errors.InvalidResponse, "OpenAI Codex reused output_index for different items"), errors.Fields{"output_index": index})
+				}
+				outputItems[index] = cloneCodexMap(item)
+			}
+		case "response.function_call_arguments.delta", "response.function_call_arguments.done":
+			key := codexToolKey(event, event)
+			builder := builders[key]
+			if builder == nil {
+				builder = &codexToolBuilder{}
+				builders[key] = builder
+			}
+			if value, ok := event["delta"].(string); ok {
+				builder.Arguments.WriteString(value)
+			}
+			if value, ok := event["arguments"].(string); ok {
+				builder.Arguments.Reset()
+				builder.Arguments.WriteString(value)
+			}
+		case "response.incomplete":
+			return nil, errors.WithFields(errors.New(errors.InvalidResponse, "OpenAI Codex response was incomplete"), errors.Fields{"event": event})
+		case "response.completed", "response.done":
+			response, ok := event["response"].(map[string]any)
+			if !ok {
+				return nil, errors.New(errors.InvalidResponse, "OpenAI Codex terminal event is missing response")
+			}
+			status, _ := response["status"].(string)
+			if status != "completed" {
+				return nil, errors.WithFields(errors.New(errors.InvalidResponse, "OpenAI Codex terminal response was not completed"), errors.Fields{"status": status})
+			}
+			result.metadata["id"] = response["id"]
+			result.metadata["status"] = status
+			setCodexUsage(result.usage, response["usage"])
+			terminal = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrap(err, errors.Unknown, "read OpenAI Codex SSE response")
+	}
+	if !terminal {
+		return nil, errors.New(errors.InvalidResponse, "OpenAI Codex SSE ended before response.completed")
+	}
+	if len(builders) > 0 {
+		return nil, errors.New(errors.InvalidResponse, "OpenAI Codex SSE ended with unfinished tool calls")
+	}
+	if len(outputItems) > 0 {
+		indices := make([]int, 0, len(outputItems))
+		for index := range outputItems {
+			indices = append(indices, index)
+		}
+		sort.Ints(indices)
+		items := make([]map[string]any, 0, len(indices))
+		seenCallIDs := make(map[string]struct{})
+		for _, index := range indices {
+			item := outputItems[index]
+			items = append(items, item)
+			if item["type"] == "function_call" {
+				builder := &codexToolBuilder{}
+				updateCodexToolBuilder(builder, item)
+				if _, exists := seenCallIDs[builder.ID]; exists {
+					return nil, errors.WithFields(errors.New(errors.InvalidResponse, "OpenAI Codex reused function call id"), errors.Fields{"call_id": builder.ID})
+				}
+				if err := appendCodexToolCall(result, builder); err != nil {
+					return nil, err
+				}
+				seenCallIDs[builder.ID] = struct{}{}
+			}
+		}
+		result.providerData = map[string]any{"openai-codex": items}
+	}
+	return result, nil
+}
+
+func sameCodexOutputIdentity(left, right map[string]any) bool {
+	leftType, leftTypeOK := left["type"].(string)
+	rightType, rightTypeOK := right["type"].(string)
+	if !leftTypeOK || !rightTypeOK || leftType == "" || leftType != rightType {
+		return false
+	}
+	for _, field := range []string{"id", "call_id"} {
+		leftRaw, leftExists := left[field]
+		rightRaw, rightExists := right[field]
+		if !leftExists && !rightExists {
+			continue
+		}
+		leftValue, leftOK := leftRaw.(string)
+		rightValue, rightOK := rightRaw.(string)
+		if !leftOK || !rightOK || leftValue == "" || leftValue != rightValue {
+			return false
+		}
+	}
+	return true
+}
+
+func codexOutputIndex(event map[string]any) (int, bool) {
+	switch value := event["output_index"].(type) {
+	case float64:
+		return int(value), value >= 0 && value == float64(int(value))
+	case int:
+		return value, value >= 0
+	default:
+		return 0, false
+	}
+}
+
+func codexToolKey(item, event map[string]any) string {
+	for _, source := range []map[string]any{item, event} {
+		for _, field := range []string{"id", "item_id", "call_id"} {
+			if value, ok := source[field].(string); ok && value != "" {
+				return value
+			}
+		}
+	}
+	return fmt.Sprintf("output_%v", event["output_index"])
+}
+func updateCodexToolBuilder(builder *codexToolBuilder, item map[string]any) {
+	if value, ok := item["call_id"].(string); ok {
+		builder.ID = value
+	}
+	if value, ok := item["name"].(string); ok {
+		builder.Name = value
+	}
+	if value, ok := item["arguments"].(string); ok {
+		builder.Arguments.Reset()
+		builder.Arguments.WriteString(value)
+	}
+}
+func appendCodexToolCall(result *openAICodexResult, builder *codexToolBuilder) error {
+	if strings.TrimSpace(builder.ID) == "" || strings.TrimSpace(builder.Name) == "" {
+		return errors.New(errors.InvalidResponse, "OpenAI Codex function call is missing call_id or name")
+	}
+	var arguments map[string]any
+	raw := builder.Arguments.String()
+	if raw == "" {
+		arguments = map[string]any{}
+	} else if err := json.Unmarshal([]byte(raw), &arguments); err != nil {
+		return errors.Wrap(err, errors.InvalidResponse, "decode OpenAI Codex tool arguments")
+	}
+	result.toolCalls = append(result.toolCalls, core.ToolCall{ID: builder.ID, Name: builder.Name, Arguments: arguments})
+	return nil
+}
+func codexMessageText(item map[string]any) string {
+	content, _ := item["content"].([]any)
+	var parts []string
+	for _, raw := range content {
+		block, _ := raw.(map[string]any)
+		if text, ok := block["text"].(string); ok {
+			parts = append(parts, text)
+		} else if refusal, ok := block["refusal"].(string); ok {
+			parts = append(parts, refusal)
+		}
+	}
+	return strings.Join(parts, "")
+}
+func setCodexUsage(target *core.TokenInfo, raw any) {
+	usage, _ := raw.(map[string]any)
+	target.PromptTokens = jsonInt(usage["input_tokens"])
+	target.CompletionTokens = jsonInt(usage["output_tokens"])
+	target.TotalTokens = jsonInt(usage["total_tokens"])
+	if target.TotalTokens == 0 {
+		target.TotalTokens = target.PromptTokens + target.CompletionTokens
+	}
+}
+func jsonInt(value any) int { number, _ := value.(float64); return int(number) }
+func headerValue(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}
+func cloneCodexMap(source map[string]any) map[string]any {
+	target := make(map[string]any, len(source))
+	for key, value := range source {
+		switch typed := value.(type) {
+		case map[string]any:
+			target[key] = cloneCodexMap(typed)
+		case []any:
+			items := make([]any, len(typed))
+			for i, item := range typed {
+				if child, ok := item.(map[string]any); ok {
+					items[i] = cloneCodexMap(child)
+				} else {
+					items[i] = item
+				}
+			}
+			target[key] = items
+		default:
+			target[key] = value
+		}
+	}
+	return target
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	target := make(map[string]string, len(source))
+	for key, value := range source {
+		target[key] = value
+	}
+	return target
+}

--- a/pkg/llms/openai_codex_agents_test.go
+++ b/pkg/llms/openai_codex_agents_test.go
@@ -1,0 +1,80 @@
+package llms_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/llms"
+	models "github.com/XiaoConstantine/mcp-go/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAICodexRunsThroughSharedAgentLoop(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		var payload map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		input := payload["input"].([]any)
+		w.Header().Set("Content-Type", "text/event-stream")
+		if request == 1 {
+			fmt.Fprint(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"opaque\",\"summary\":[]}}\n\n")
+			fmt.Fprint(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"echo\",\"arguments\":\"{\\\"value\\\":\\\"pong\\\"}\"}}\n\n")
+			fmt.Fprint(w, "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n")
+			return
+		}
+		require.GreaterOrEqual(t, len(input), 4)
+		assert.Equal(t, "reasoning", input[1].(map[string]any)["type"])
+		assert.Equal(t, "function_call", input[2].(map[string]any)["type"])
+		assert.Equal(t, "function_call_output", input[3].(map[string]any)["type"])
+		fmt.Fprint(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"pong\"}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\",\"annotations\":[]}]}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n")
+	}))
+	defer server.Close()
+
+	llm, err := llms.NewOpenAICodexLLM("gpt-5.4",
+		llms.WithOpenAICodexBaseURL(server.URL),
+		llms.WithOpenAICodexHTTPClient(server.Client()),
+		llms.WithOpenAICodexCredentials(func(context.Context, string) (llms.OpenAICodexCredentials, error) {
+			return llms.OpenAICodexCredentials{AccessToken: "token", AccountID: "account"}, nil
+		}),
+	)
+	require.NoError(t, err)
+	adapter, err := agents.NewLLMAdapter(llm)
+	require.NoError(t, err)
+	result, err := agents.RunLoop(context.Background(), adapter, []core.Tool{echoTool{}},
+		[]agents.Message{agents.NewTextMessage(agents.RoleUser, "echo pong")}, agents.LoopConfig{
+			RunID: "codex-loop", Task: "echo pong", MaxTurns: 3, Completion: agents.TextCompletion(),
+		})
+	require.NoError(t, err)
+	assert.Equal(t, agents.StopReasonText, result.StopReason)
+	assert.Equal(t, "pong", result.FinalAnswer)
+	assert.Equal(t, 1, result.ToolCalls)
+	assert.Equal(t, int32(2), requests.Load())
+	require.NotEmpty(t, result.Messages[1].ProviderData)
+}
+
+type echoTool struct{}
+
+func (echoTool) Name() string        { return "echo" }
+func (echoTool) Description() string { return "return a value" }
+func (t echoTool) Metadata() *core.ToolMetadata {
+	return &core.ToolMetadata{Name: t.Name(), Description: t.Description(), InputSchema: t.InputSchema()}
+}
+func (echoTool) CanHandle(context.Context, string) bool { return true }
+func (echoTool) Validate(map[string]any) error          { return nil }
+func (echoTool) Execute(_ context.Context, arguments map[string]any) (core.ToolResult, error) {
+	return core.ToolResult{Data: arguments["value"]}, nil
+}
+func (echoTool) InputSchema() models.InputSchema {
+	return models.InputSchema{Type: "object", Properties: map[string]models.ParameterSchema{"value": {Type: "string"}}}
+}

--- a/pkg/llms/openai_codex_test.go
+++ b/pkg/llms/openai_codex_test.go
@@ -1,0 +1,248 @@
+package llms
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAICodexLive(t *testing.T) {
+	accessToken := os.Getenv("DSPY_GO_CODEX_LIVE_ACCESS_TOKEN")
+	accountID := os.Getenv("DSPY_GO_CODEX_LIVE_ACCOUNT_ID")
+	if accessToken == "" || accountID == "" {
+		t.Skip("set DSPY_GO_CODEX_LIVE_ACCESS_TOKEN and DSPY_GO_CODEX_LIVE_ACCOUNT_ID")
+	}
+	model := os.Getenv("DSPY_GO_CODEX_LIVE_MODEL")
+	if model == "" {
+		model = "gpt-5.4"
+	}
+	llm, err := NewOpenAICodexLLM(core.ModelID(model), WithOpenAICodexCredentials(
+		func(context.Context, string) (OpenAICodexCredentials, error) {
+			return OpenAICodexCredentials{AccessToken: accessToken, AccountID: accountID}, nil
+		},
+	))
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	tools := []map[string]any{{
+		"name": "echo", "description": "Return the supplied value",
+		"parameters": map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}, "required": []string{"value"}},
+	}}
+	first, err := llm.GenerateWithTools(ctx, []core.ChatMessage{
+		{Role: "system", Content: []core.ContentBlock{core.NewTextBlock("Call echo exactly once with value pong. After its result, answer with that result without calling another tool.")}},
+		{Role: "user", Content: []core.ContentBlock{core.NewTextBlock("Begin")}},
+	}, tools)
+	require.NoError(t, err)
+	calls, ok := first["tool_calls"].([]core.ToolCall)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	require.Equal(t, "echo", calls[0].Name)
+
+	second, err := llm.GenerateWithTools(ctx, []core.ChatMessage{
+		{Role: "system", Content: []core.ContentBlock{core.NewTextBlock("Call echo exactly once with value pong. After its result, answer with that result without calling another tool.")}},
+		{Role: "user", Content: []core.ContentBlock{core.NewTextBlock("Begin")}},
+		{Role: "assistant", ToolCalls: calls, ProviderData: first["provider_data"].(map[string]any)},
+		{Role: "tool", ToolResult: &core.ChatToolResult{ToolCallID: calls[0].ID, Name: "echo", Content: []core.ContentBlock{core.NewTextBlock("pong")}}},
+	}, tools)
+	require.NoError(t, err)
+	assert.Contains(t, strings.ToLower(second["content"].(string)), "pong")
+}
+
+func TestOpenAICodexGenerateWithToolsUsesResponsesProtocol(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, "/codex/responses", r.URL.Path)
+		assert.Equal(t, "Bearer access-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "account-123", r.Header.Get("ChatGPT-Account-ID"))
+		assert.Equal(t, "test-suite", r.Header.Get("Originator"))
+		assert.Equal(t, "text/event-stream", r.Header.Get("Accept"))
+
+		var payload map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Equal(t, "gpt-5.2-codex", payload["model"])
+		assert.Equal(t, true, payload["stream"])
+		assert.Equal(t, false, payload["store"])
+		input := payload["input"].([]any)
+		if requests.Load() == 1 {
+			assert.Equal(t, "coding instructions", payload["instructions"])
+			require.Len(t, input, 3)
+			assert.Equal(t, "function_call", input[0].(map[string]any)["type"])
+			assert.Equal(t, "function_call_output", input[1].(map[string]any)["type"])
+			tools := payload["tools"].([]any)
+			require.Len(t, tools, 1)
+			assert.Equal(t, "read", tools[0].(map[string]any)["name"])
+			assert.Equal(t, false, tools[0].(map[string]any)["strict"])
+		} else {
+			require.GreaterOrEqual(t, len(input), 2)
+			assert.Equal(t, "reasoning", input[0].(map[string]any)["type"])
+			assert.Equal(t, "encrypted-value", input[0].(map[string]any)["encrypted_content"])
+			assert.Equal(t, "function_call", input[1].(map[string]any)["type"])
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"encrypted-value\",\"summary\":[]}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"read\",\"arguments\":\"\"}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"read\",\"arguments\":\"{\\\"path\\\":\\\"README.md\\\"}\"}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4,\"total_tokens\":14}}}\n\n")
+	}))
+	defer server.Close()
+
+	var resolves atomic.Int32
+	llm, err := NewOpenAICodexLLM("gpt-5.2-codex",
+		WithOpenAICodexBaseURL(server.URL),
+		WithOpenAICodexOriginator("test-suite"),
+		WithOpenAICodexHTTPClient(server.Client()),
+		WithOpenAICodexCredentials(func(context.Context, string) (OpenAICodexCredentials, error) {
+			resolves.Add(1)
+			return OpenAICodexCredentials{AccessToken: "access-token", AccountID: "account-123"}, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	messages := []core.ChatMessage{
+		{Role: "system", Content: []core.ContentBlock{core.NewTextBlock("coding instructions")}},
+		{Role: "assistant", ToolCalls: []core.ToolCall{{ID: "previous-call", Name: "ls", Arguments: map[string]any{}}}},
+		{Role: "tool", ToolResult: &core.ChatToolResult{ToolCallID: "previous-call", Name: "ls", Content: []core.ContentBlock{core.NewTextBlock("README.md")}}},
+		{Role: "user", Content: []core.ContentBlock{core.NewTextBlock("Read it")}},
+	}
+	result, err := llm.GenerateWithTools(context.Background(), messages, []map[string]any{{
+		"name": "read", "description": "read a file", "parameters": map[string]any{"type": "object"},
+	}})
+	require.NoError(t, err)
+	calls := result["tool_calls"].([]core.ToolCall)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "call_1", calls[0].ID)
+	assert.Equal(t, "README.md", calls[0].Arguments["path"])
+	assert.Equal(t, &core.TokenInfo{PromptTokens: 10, CompletionTokens: 4, TotalTokens: 14}, result["_usage"])
+	assert.Equal(t, int32(1), requests.Load())
+	assert.Equal(t, int32(1), resolves.Load())
+
+	providerData := result["provider_data"].(map[string]any)
+	_, err = llm.GenerateWithTools(context.Background(), []core.ChatMessage{
+		{Role: "assistant", ToolCalls: calls, ProviderData: providerData},
+		{Role: "tool", ToolResult: &core.ChatToolResult{ToolCallID: "call_1", Name: "read", Content: []core.ContentBlock{core.NewTextBlock("contents")}}},
+		{Role: "user", Content: []core.ContentBlock{core.NewTextBlock("continue")}},
+	}, []map[string]any{{"name": "read", "parameters": map[string]any{"type": "object"}}})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), resolves.Load(), "credentials must resolve for every request")
+}
+
+func TestOpenAICodexRetriesUnauthorizedWithForcedRefresh(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		if request == 1 {
+			assert.Equal(t, "Bearer stale", r.Header.Get("Authorization"))
+			http.Error(w, "expired", http.StatusUnauthorized)
+			return
+		}
+		assert.Equal(t, "Bearer fresh", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n")
+	}))
+	defer server.Close()
+
+	var resolutions []string
+	llm, err := NewOpenAICodexLLM("gpt-5.2-codex",
+		WithOpenAICodexBaseURL(server.URL), WithOpenAICodexHTTPClient(server.Client()),
+		WithOpenAICodexCredentials(func(_ context.Context, rejectedAccessToken string) (OpenAICodexCredentials, error) {
+			resolutions = append(resolutions, rejectedAccessToken)
+			token := "stale"
+			if rejectedAccessToken != "" {
+				token = "fresh"
+			}
+			return OpenAICodexCredentials{AccessToken: token, AccountID: "account"}, nil
+		}),
+	)
+	require.NoError(t, err)
+	response, err := llm.Generate(context.Background(), "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", response.Content)
+	assert.Equal(t, []string{"", "stale"}, resolutions)
+	assert.Equal(t, int32(2), requests.Load())
+}
+
+func TestOpenAICodexRejectsMalformedContinuation(t *testing.T) {
+	llm, err := NewOpenAICodexLLM("gpt-5.4", WithOpenAICodexCredentials(
+		func(context.Context, string) (OpenAICodexCredentials, error) {
+			return OpenAICodexCredentials{AccessToken: "token", AccountID: "account"}, nil
+		},
+	))
+	require.NoError(t, err)
+	cycle := map[string]any{"type": "reasoning"}
+	cycle["self"] = cycle
+	for _, providerData := range []map[string]any{
+		{"openai-codex": []any{"not-an-object"}},
+		{"openai-codex": []any{}},
+		{"openai-codex": []any{cycle}},
+	} {
+		_, err = llm.requestPayload([]core.ChatMessage{{Role: "assistant", ProviderData: providerData}}, nil)
+		require.Error(t, err)
+	}
+}
+
+func TestParseOpenAICodexSSERequiresCompletedTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		sse  string
+	}{
+		{name: "clean eof", sse: `data: {"type":"response.output_text.delta","delta":"partial"}\n\n`},
+		{name: "done marker only", sse: "data: [DONE]\n\n"},
+		{name: "incomplete", sse: `data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}}\n\n`},
+		{name: "unfinished call", sse: `data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"read"}}\n\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n`},
+		{name: "missing call id", sse: `data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","name":"read","arguments":"{}"}}\n\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n`},
+		{name: "terminal failed status", sse: `data: {"type":"response.completed","response":{"status":"failed"}}\n\n`},
+		{name: "terminal missing response", sse: `data: {"type":"response.completed"}\n\n`},
+		{name: "terminal missing status", sse: `data: {"type":"response.completed","response":{}}\n\n`},
+		{name: "duplicate index conflicting call id", sse: `data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"first","arguments":"{}"}}\n\ndata: {"type":"response.output_item.completed","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_2","name":"second","arguments":"{}"}}\n\n`},
+		{name: "duplicate index malformed type", sse: `data: {"type":"response.output_item.done","output_index":0,"item":{"type":["message"],"id":"msg_1"}}\n\ndata: {"type":"response.output_item.completed","output_index":0,"item":{"type":["message"],"id":"msg_1"}}\n\n`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := parseOpenAICodexSSE(strings.NewReader(strings.ReplaceAll(test.sse, `\n`, "\n")))
+			require.Error(t, err)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestParseOpenAICodexSSEOrdersToolCallsByOutputIndex(t *testing.T) {
+	sse := `data: {"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc_2","call_id":"call_2","name":"second","arguments":"{}"}}\n\ndata: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"first","arguments":"{}"}}\n\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n`
+	result, err := parseOpenAICodexSSE(strings.NewReader(strings.ReplaceAll(sse, `\n`, "\n")))
+	require.NoError(t, err)
+	require.Len(t, result.toolCalls, 2)
+	assert.Equal(t, "call_1", result.toolCalls[0].ID)
+	assert.Equal(t, "call_2", result.toolCalls[1].ID)
+}
+
+func TestOpenAICodexAccountID(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"https://api.openai.com/auth":{"chatgpt_account_id":"acct-42"}}`))
+	got, err := OpenAICodexAccountID("header." + payload + ".signature")
+	require.NoError(t, err)
+	assert.Equal(t, "acct-42", got)
+}
+
+func TestOpenAICodexFactoryUsesAccountIDFromToken(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"https://api.openai.com/auth":{"chatgpt_account_id":"acct-42"}}`))
+	llm, err := NewOpenAICodexLLMFromConfig(context.Background(), core.ProviderConfig{
+		Name: "openai-codex", APIKey: "opaque-access-token",
+		Params: map[string]any{"id_token": "header." + payload + ".signature"},
+	}, "gpt-5.2-codex")
+	require.NoError(t, err)
+	assert.Equal(t, "openai-codex", llm.ProviderName())
+}

--- a/pkg/llms/openai_test.go
+++ b/pkg/llms/openai_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOpenAIExplicitAPIKeyPrecedesEnvironment(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "environment-key")
+	t.Setenv("OPENAI_OAUTH_TOKEN", "oauth-token-for-separate-provider")
+
+	llm, err := NewOpenAILLM(core.ModelOpenAIGPT4, WithAPIKey("explicit-key"))
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer explicit-key", llm.GetEndpointConfig().Headers["Authorization"])
+	assert.Empty(t, llm.GetEndpointConfig().Headers["openai-beta"])
+}
+
 func TestNewOpenAILLM(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- add a distinct `openai-codex` provider for ChatGPT Plus/Pro subscription access through the Codex Responses endpoint
- preserve ordered opaque Responses output items across canonical agent turns without adding another execution loop
- resolve credentials per operation and force one refresh after HTTP 401
- harden OpenAI OAuth with independent state, form-encoded context-aware token operations, and account-ID resolution
- keep API-key OpenAI transport separate and make explicit API-key configuration authoritative

## Protocol and safety

- sends subscription credentials only to `chatgpt.com/backend-api/codex/responses`
- supplies `ChatGPT-Account-ID`, OAuth bearer auth, and Responses headers
- rejects incomplete/truncated/malformed SSE, unfinished calls, invalid terminal state, conflicting output indices, duplicate call IDs, and malformed continuation data
- preserves encrypted reasoning and output ordering in dedicated `Message.ProviderData`, outside diagnostics and traces
- application-owned credential resolver supports secure storage and refresh-token rotation

## Compatibility

`OPENAI_OAUTH_TOKEN` is now reserved for `openai-codex`; the regular `openai` provider accepts API keys and no longer routes OAuth tokens through Chat Completions. Explicit API-key configuration takes precedence over `OPENAI_API_KEY`.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`
- `hugo --source docs --destination /tmp/dspy-go-docs-build`
- live ChatGPT subscription smoke using `gpt-5.4`, including a two-turn tool call with encrypted continuation replay
- independent Codex review: no actionable findings
